### PR TITLE
feat: Parse shapefile sidecar files

### DIFF
--- a/ui/src/utils/shapefile/parse-shp-header.tsx
+++ b/ui/src/utils/shapefile/parse-shp-header.tsx
@@ -1,0 +1,62 @@
+// Lifted from https://github.com/visgl/loaders.gl/blob/ad75df5bd79d8ff21f3a598cc5d10e97786e47ba/modules/shapefile/src/lib/parsers/parse-shp-header.ts
+
+export interface SHPHeader {
+  /** SHP Magic number */
+  magic: number;
+
+  /** Number of bytes in file */
+  length: number;
+  version: number;
+  type: number;
+  bbox: {
+    minX: number;
+    minY: number;
+    minZ: number;
+    minM: number;
+    maxX: number;
+    maxY: number;
+    maxZ: number;
+    maxM: number;
+  };
+}
+
+const LITTLE_ENDIAN = true;
+const BIG_ENDIAN = false;
+const SHP_MAGIC_NUMBER = 0x0000270a;
+
+/**
+ * Extract the binary header
+ * Note: Also used by SHX
+ * @param headerView
+ * @returns SHPHeader
+ */
+export function parseSHPHeader(headerView: DataView): SHPHeader {
+  // Note: The SHP format switches endianness between fields!
+  // https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
+  const header = {
+    magic: headerView.getInt32(0, BIG_ENDIAN),
+    // Length is stored as # of 2-byte words; multiply by 2 to get # of bytes
+    length: headerView.getInt32(24, BIG_ENDIAN) * 2,
+    version: headerView.getInt32(28, LITTLE_ENDIAN),
+    type: headerView.getInt32(32, LITTLE_ENDIAN),
+    bbox: {
+      minX: headerView.getFloat64(36, LITTLE_ENDIAN),
+      minY: headerView.getFloat64(44, LITTLE_ENDIAN),
+      minZ: headerView.getFloat64(68, LITTLE_ENDIAN),
+      minM: headerView.getFloat64(84, LITTLE_ENDIAN),
+      maxX: headerView.getFloat64(52, LITTLE_ENDIAN),
+      maxY: headerView.getFloat64(60, LITTLE_ENDIAN),
+      maxZ: headerView.getFloat64(76, LITTLE_ENDIAN),
+      maxM: headerView.getFloat64(92, LITTLE_ENDIAN),
+    },
+  };
+  if (header.magic !== SHP_MAGIC_NUMBER) {
+    // eslint-disable-next-line
+    console.error(`SHP file: bad magic number ${header.magic}`);
+  }
+  if (header.version !== 1000) {
+    // eslint-disable-next-line
+    console.error(`SHP file: bad version ${header.version}`);
+  }
+  return header;
+}

--- a/ui/src/utils/shapefile/parse-shx.ts
+++ b/ui/src/utils/shapefile/parse-shx.ts
@@ -1,0 +1,37 @@
+// Lifted from https://github.com/visgl/loaders.gl/blob/ad75df5bd79d8ff21f3a598cc5d10e97786e47ba/modules/shapefile/src/lib/parsers/parse-shx.ts
+import { parseSHPHeader } from './parse-shp-header';
+
+export interface SHXOutput {
+  offsets: Int32Array;
+  lengths: Int32Array;
+}
+
+const SHX_HEADER_SIZE = 100;
+const BIG_ENDIAN = false;
+
+/**
+ * @param arrayBuffer
+ * @returns SHXOutput
+ */
+export function parseShx(arrayBuffer: ArrayBuffer): SHXOutput {
+  // SHX header is identical to SHP Header
+  const headerView = new DataView(arrayBuffer, 0, SHX_HEADER_SIZE);
+  const header = parseSHPHeader(headerView);
+  const contentLength = header.length - SHX_HEADER_SIZE;
+
+  const contentView = new DataView(arrayBuffer, SHX_HEADER_SIZE, contentLength);
+
+  const offsets = new Int32Array(contentLength);
+  const lengths = new Int32Array(contentLength);
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < contentLength / 8; i++) {
+    offsets[i] = contentView.getInt32(i * 8, BIG_ENDIAN);
+    lengths[i] = contentView.getInt32(i * 8 + 4, BIG_ENDIAN);
+  }
+
+  return {
+    offsets,
+    lengths,
+  };
+}

--- a/ui/src/utils/shapefile/shapefile.ts
+++ b/ui/src/utils/shapefile/shapefile.ts
@@ -1,10 +1,53 @@
+/* eslint-disable no-restricted-syntax */
+
 // Lifted from https://github.com/visgl/loaders.gl/blob/ad75df5bd79d8ff21f3a598cc5d10e97786e47ba/modules/shapefile/src/lib/parsers/parse-shapefile.ts
 // so we can support loading shapefiles in the form of an array of ArrayBuffers from ZipLoader
 import { binaryToGeometry } from '@loaders.gl/gis';
 import '@loaders.gl/polyfills';
 import type { BinaryGeometry, Geometry } from '@loaders.gl/schema';
+import { parseShx } from './parse-shx';
 
 type Feature = any;
+
+interface SHXOutput {
+  offsets: Int32Array;
+  lengths: Int32Array;
+}
+
+const _getFilenameByExtension = (filenames: string[], extension: string) => (
+  filenames.find((filename) => filename.endsWith(extension))
+);
+
+const _arrayBufferToText = (arrayBuf: ArrayBuffer): string => {
+  const uint8Array = new Uint8Array(arrayBuf);
+  const textDecoder = new TextDecoder('utf-8'); // Specify the encoding if it's different
+  return textDecoder.decode(uint8Array);
+};
+
+export const loadShapefileSidecarFiles = (zipFileMap: {
+  [key: string]: ArrayBuffer,
+}): {
+  shx?: SHXOutput,
+  cpg?: string;
+  prj?: string;
+} => {
+  const filenames = Object.keys(zipFileMap);
+
+  const filenameCpg = _getFilenameByExtension(filenames, '.cpg');
+  const cpg = _arrayBufferToText(zipFileMap[filenameCpg]);
+
+  const filenamePrj = _getFilenameByExtension(filenames, '.prj');
+  const prj = _arrayBufferToText(zipFileMap[filenamePrj]);
+
+  const filenameShx = _getFilenameByExtension(filenames, '.shx');
+  const shx = parseShx(zipFileMap[filenameShx]);
+
+  return {
+    shx,
+    cpg,
+    prj,
+  };
+};
 
 export const joinProperties = (geometries: Geometry[], properties: object[]): Feature[] => {
   const features: Feature[] = [];


### PR DESCRIPTION
See title - of particular interest is the `.prj` file in case the shp geometries need to be reprojected. Most of the code is lifted from `@loaders.gl/shapefile` lib source that aren't exposed for api use. The changes are mostly from consuming the sidecar files as `ArrayBuffer`s from the ZipLoader rather than url-fetch results.