### PR TITLE
[wip] feat: Integrate entity parsing and elasticsearch keyword search to broader search component

### DIFF
--- a/api/app/document.py
+++ b/api/app/document.py
@@ -1,17 +1,19 @@
 import re
+
 from elasticsearch_dsl import (
     Date,
+    DateHistogramFacet,
     Document,
+    FacetedSearch,
     GeoShape,
     Index,
     Integer,
     Keyword,
     Object,
-    Text,
     Q,
+    TermsFacet,
+    Text,
 )
-from elasticsearch_dsl import FacetedSearch, TermsFacet, DateHistogramFacet
-
 
 DOC_INDEX = 'datasets'
 datasets = Index(DOC_INDEX)
@@ -31,13 +33,17 @@ class Dataset(Document):
     description = Text(analyzer='snowball')
     projection = Keyword()
     properties = Object()
-    bbox = GeoShape()
+    # we have a couple bboxes whose lonlats are all the same points
+    # indexing it as a GeoShape results in an error
+    # `failed to parse field [bbox] of type [geo_shape]`
+    bbox = Keyword()
 
     class Index:
         name = DOC_INDEX
         settings = {
             "number_of_shards": 2,
-            "number_of_replicas": 1,
+            # just to keep the health status green for now
+            "number_of_replicas": 0,
             "highlight": {"max_analyzed_offset": 5000000},
             "max_terms_count": 262144,  # 2 ^ 18
             "refresh_interval": "30s"

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -38,6 +38,7 @@ class DatasetCountsRequest(BaseModel):
     location: str | None = None
     source_org: Optional[List[str]] = []
     accessibility: Optional[List[str]] = []
+    dataset_ids: Optional[List[int]] = []
     debug_json_response: bool = False
     ignore_cache: bool = False
 

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -63,6 +63,7 @@ class DatasetsByLocationRequest(BaseModel):
     resolution: int
     source_org: Optional[List[str]] = []
     accessibility: Optional[List[str]] = []
+    dataset_ids: Optional[List[int]] = []
 
 
 class TifAsPngRequest(BaseModel):

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -51,6 +51,7 @@ class IndexedDatasetCountRequest(BaseModel):
 class DatasetMetadataRequest(BaseModel):
     source_org: Optional[List[str]] = []
     accessibility: Optional[List[str]] = []
+    dataset_ids: Optional[List[int]] = []
 
 
 class DatasetRequest(BaseModel):

--- a/api/app/routers/dataset.py
+++ b/api/app/routers/dataset.py
@@ -139,14 +139,13 @@ async def get_datasets_by_location(
     ]
 
 
-# rename endpoint to datasets_by_h3_index
+# TODO: rename endpoint to datasets_by_h3_index
 @router.post("/dataset_metadata/{index}")
 async def get_dataset_metadata(
     index: str,
     payload: DatasetMetadataRequest,
     session: AsyncSession = Depends(get_async_session),
 ):
-    # TODO: further by dataset_ids if available
     filters = {
         attr: getattr(payload, attr)
         for attr in ["source_org", "accessibility", "dataset_ids"]

--- a/api/app/routers/dataset.py
+++ b/api/app/routers/dataset.py
@@ -149,7 +149,7 @@ async def get_dataset_metadata(
     # TODO: further by dataset_ids if available
     filters = {
         attr: getattr(payload, attr)
-        for attr in ["source_org", "accessibility"]
+        for attr in ["source_org", "accessibility", "dataset_ids"]
         if getattr(payload, attr)
     }
     results = await get_dataset_metadata_results(session, target=index, filters=filters)

--- a/api/app/routers/dataset.py
+++ b/api/app/routers/dataset.py
@@ -34,12 +34,11 @@ async def get_dataset_counts(
     y: int,
     session: AsyncSession = Depends(get_async_session),
 ):
-    # needs to be filterable with dataset ids
-    filters = {}
-    if payload.source_org:
-        filters["source_org"] = payload.source_org
-    if payload.accessibility:
-        filters["accessibility"] = payload.accessibility
+    filters = {
+        attr: getattr(payload, attr)
+        for attr in ["source_org", "accessibility", "dataset_ids"]
+        if getattr(payload, attr)
+    }
     location = payload.location
     should_hit_cache = not (payload.ignore_cache or location or filters)
     dataset_count_bytes = None
@@ -99,7 +98,7 @@ async def get_dataset_coverage(
 
 
 # only called if keyword search is not used so we
-# do not need the option to filter by dataset_ids
+# do not yet need the option to filter by dataset_ids
 @router.post("/dataset_count/")
 async def get_dataset_count(
     payload: IndexedDatasetCountRequest,
@@ -147,6 +146,7 @@ async def get_dataset_metadata(
     payload: DatasetMetadataRequest,
     session: AsyncSession = Depends(get_async_session),
 ):
+    # TODO: further by dataset_ids if available
     filters = {
         attr: getattr(payload, attr)
         for attr in ["source_org", "accessibility"]

--- a/api/app/routers/search.py
+++ b/api/app/routers/search.py
@@ -1,10 +1,8 @@
 from typing import Union
-from fastapi import APIRouter
-from fastapi import Query
 
-from app.search.parser import parse_query
 from app.search.es import keyword_search
-
+from app.search.parser import parse_query
+from fastapi import APIRouter, Query
 
 router = APIRouter(
     prefix="/search",
@@ -12,11 +10,17 @@ router = APIRouter(
 )
 
 @router.get("/parse")
-def parse(query: Union[str, None] = None, labels: list[str] = Query(["year", "country", "statistical indicator", "region"], description="A set of labels for tagging segments of the query."), threshold: float = 0.3, nested_ner: bool = False):
-
+def parse(
+    query: Union[str, None] = None,
+    labels: list[str] = Query(
+        ["year", "country", "statistical indicator", "region"],
+        description="A set of labels for tagging segments of the query."
+    ),
+    threshold: float = 0.3,
+    nested_ner: bool = False
+):
     if query is None:
         return {"error": "Query parameter is required."}
-
     return parse_query(query, labels, threshold, nested_ner)
 
 

--- a/api/app/routers/search.py
+++ b/api/app/routers/search.py
@@ -1,13 +1,35 @@
+import os
 from typing import Union
 
 from app.search.es import keyword_search
 from app.search.parser import parse_query
+from elasticsearch.client import IndicesClient
 from fastapi import APIRouter, Query
+
+from elasticsearch import Elasticsearch
 
 router = APIRouter(
     prefix="/search",
     tags=["search"]
 )
+
+ELASTICSEARCH_CONNECTION = os.getenv("ELASTICSEARCH_URL_SYNC")
+client = Elasticsearch(ELASTICSEARCH_CONNECTION)
+indices_client = IndicesClient(client)
+
+
+@router.get("/strip_stop_words")
+def strip_stop_words(
+    query: str
+):
+    return indices_client.analyze(
+        body={
+            "tokenizer": "standard",
+            "filter": ["stop"],
+            "text": query,
+        }
+    )
+
 
 @router.get("/parse")
 def parse(
@@ -35,5 +57,4 @@ def search_keyword(
     from_result: int = Query(0, description="The starting index"),
     size: int = Query(10, description="The number of results to return"),
 ):
-
     return keyword_search(query, source_org, accessibility, projection, min_year, max_year, from_result, size)

--- a/api/app/search/es.py
+++ b/api/app/search/es.py
@@ -1,9 +1,10 @@
 import os
-from typing import List
 from datetime import datetime
+from typing import List
+
 from app.document import DatasetFacetedSearch
 from elasticsearch_dsl import connections
-
+from shapely import wkt
 
 ELASTICSEARCH_CONNECTION = os.getenv("ELASTICSEARCH_URL_SYNC")
 connections.create_connection(
@@ -22,7 +23,9 @@ def keyword_search(
     from_result: int = 0,
     size: int = 10,
 ):
-    '''This endpoint provides the service for the keyword search functionality. This uses Elasticsearch in the backend for the full-text search.
+    '''
+    This endpoint provides the service for the keyword search functionality.
+    This uses Elasticsearch in the backend for the full-text search.
     '''
 
     filters = dict(
@@ -63,7 +66,10 @@ def keyword_search(
 
     for ix, h in enumerate(response, 1):
         highlight = {}
-        hits.append(h.to_dict())
+        h_dict = h.to_dict()
+        h_dict["id"] = h_dict.pop("pg_id")
+        h_dict["bbox"] = wkt.loads(h_dict.pop("bbox")).bounds
+        hits.append(h_dict)
         result.append(dict(id=h.meta.id, rank=ix +
                       from_result, score=h.meta.score))
         try:

--- a/api/app/search/parser.py
+++ b/api/app/search/parser.py
@@ -1,11 +1,10 @@
 from gradio_client import Client
 
-
 # Initialize the client
 client = Client("avsolatorio/query-parser")
 
 
-def parse_query(query: str, labels: list, threshold: float = 0.3, nested_ner: bool = False, model_name: str = "urchade/gliner_medium-v2.1"):
+def parse_query(query: str, labels: list, threshold: float = 0.3, nested_ner: bool = False, model_name: str = "urchade/gliner_base"):
     """Parse the query and extract entities. This function is a wrapper for the Gradio API
     running on the Hugging Face Space: https://huggingface.co/spaces/avsolatorio/query-parser.
 

--- a/api/app/services.py
+++ b/api/app/services.py
@@ -36,15 +36,18 @@ def build_dataset_count_tiles_query(z: int, x: int, y: int, resolution: int, loc
     dataset_counts_query = DATASET_COUNTS_FILTERED if filters else DATASET_COUNTS
 
     candidate_datasets_stmt = select(Dataset.id)
-    if source_org := filters.get("source_org"):
-        candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.source_org.in_(source_org))
-    if accessibility := filters.get("accessibility"):
-        conditions = []
-        if "Others" in accessibility:
-            conditions.append(Dataset.accessibility == None)
-            accessibility.remove("Others")
-        conditions.append(Dataset.accessibility.in_(accessibility))
-        candidate_datasets_stmt = candidate_datasets_stmt.where(or_(*conditions))
+    if dataset_ids := filters.get("dataset_ids"):
+        candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.id.in_(dataset_ids))
+    else:
+        if source_org := filters.get("source_org"):
+            candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.source_org.in_(source_org))
+        if accessibility := filters.get("accessibility"):
+            conditions = []
+            if "Others" in accessibility:
+                conditions.append(Dataset.accessibility == None)
+                accessibility.remove("Others")
+            conditions.append(Dataset.accessibility.in_(accessibility))
+            candidate_datasets_stmt = candidate_datasets_stmt.where(or_(*conditions))
 
     compiled = candidate_datasets_stmt.compile(compile_kwargs={"literal_binds": True})
     filter_kwargs = { "candidate_datasets_query": compiled } if filters else {}

--- a/api/app/services.py
+++ b/api/app/services.py
@@ -7,6 +7,7 @@ from app.models import Dataset
 from app.sql.bounds_fill import FILL, FILL_RES2
 from app.sql.dataset_counts import DATASET_COUNTS, DATASET_COUNTS_FILTERED
 from app.sql.dataset_metadata import DATASET_METADATA, DATASET_METADATA_FILTERED
+from app.sql.datasets_by_location import get_datasets_by_location_query
 from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -80,6 +81,37 @@ def dataset_count_to_bytes(dataset_counts):
         writer.write_table(table)
     serialized_data = sink.getvalue()
     return serialized_data.to_pybytes()
+
+
+# add return type
+async def get_datasets_by_location_results(session: Session, location: str, resolution: int, filters: dict[str, List[str]]={}):
+    query_kwargs = { "resolution": resolution }
+    if dataset_ids := filters.get("dataset_ids"):
+        candidate_datasets_stmt = text(f"""
+           SELECT id, ordinality
+           FROM UNNEST(ARRAY[{','.join(str(id) for id in dataset_ids)}])
+           WITH ORDINALITY AS element_list(id, ordinality)
+        """)
+        candidate_datasets_stmt = candidate_datasets_stmt.compile(compile_kwargs={"literal_binds": True})
+        query_kwargs["candidate_datasets_cte"] = f"candidate_datasets AS ({candidate_datasets_stmt}),"
+        query_kwargs["has_ordinality"] = True
+    elif filters:
+        candidate_datasets_stmt = select(Dataset.id)
+        if source_org := filters.get("source_org"):
+            candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.source_org.in_(source_org))
+        if accessibility := filters.get("accessibility"):
+            conditions = []
+            if "Others" in accessibility:
+                conditions.append(Dataset.accessibility == None)
+                accessibility.remove("Others")
+            conditions.append(Dataset.accessibility.in_(accessibility))
+            candidate_datasets_stmt = candidate_datasets_stmt.where(or_(*conditions))
+        candidate_datasets_stmt = candidate_datasets_stmt.compile(compile_kwargs={"literal_binds": True})
+        query_kwargs["candidate_datasets_cte"] = f"candidate_datasets AS ({candidate_datasets_stmt}),"
+    query = get_datasets_by_location_query(**query_kwargs)
+    query = text(query).bindparams(location=location, resolution=resolution)
+    results = await session.execute(query)
+    return results.fetchall()
 
 
 async def get_dataset_metadata_results(session: Session, target: str, filters: dict[str, List[str]]={}):

--- a/api/app/services.py
+++ b/api/app/services.py
@@ -120,15 +120,18 @@ async def get_datasets_by_location_results(session: Session, location: str, reso
 async def get_dataset_metadata_results(session: Session, target: str, filters: dict[str, List[str]]={}):
     dataset_metadata_query = DATASET_METADATA_FILTERED if filters else DATASET_METADATA
     candidate_datasets_stmt = select(Dataset.id.label("dataset_id"))
-    if source_org := filters.get("source_org"):
-        candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.source_org.in_(source_org))
-    if accessibility := filters.get("accessibility"):
-        conditions = []
-        if "Others" in accessibility:
-            conditions.append(Dataset.accessibility == None)
-            accessibility.remove("Others")
-        conditions.append(Dataset.accessibility.in_(accessibility))
-        candidate_datasets_stmt = candidate_datasets_stmt.where(or_(*conditions))
+    if dataset_ids := filters.get("dataset_ids"):
+        candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.id.in_(dataset_ids))
+    else:
+        if source_org := filters.get("source_org"):
+            candidate_datasets_stmt = candidate_datasets_stmt.where(Dataset.source_org.in_(source_org))
+        if accessibility := filters.get("accessibility"):
+            conditions = []
+            if "Others" in accessibility:
+                conditions.append(Dataset.accessibility == None)
+                accessibility.remove("Others")
+            conditions.append(Dataset.accessibility.in_(accessibility))
+            candidate_datasets_stmt = candidate_datasets_stmt.where(or_(*conditions))
     compiled = candidate_datasets_stmt.compile(compile_kwargs={"literal_binds": True})
     filter_kwargs = { "candidate_datasets_query": compiled } if filters else {}
     query = dataset_metadata_query.format(

--- a/api/app/sql/datasets_by_location.py
+++ b/api/app/sql/datasets_by_location.py
@@ -25,9 +25,11 @@ with_parents AS (
 ),
 {candidate_datasets_cte}
 located_datasets AS (
-  SELECT DISTINCT(dataset_id) id FROM h3_data JOIN with_parents ON h3_index = ANY(parents)
-  UNION ALL
-  SELECT DISTINCT(dataset_id) id FROM h3_children_indicators JOIN fill ON h3_index = fill_index
+  SELECT DISTINCT(id) FROM (
+    SELECT dataset_id id FROM h3_data JOIN with_parents ON h3_index = ANY(parents)
+    UNION ALL
+    SELECT dataset_id id FROM h3_children_indicators JOIN fill ON h3_index = fill_index
+  ) parent_children_datasets
 )
 SELECT
   id,
@@ -41,21 +43,46 @@ SELECT
   date_start,
   date_end
 FROM datasets JOIN located_datasets USING (id)
-{candidate_datasets_join}
+"""
+
+# TODO: filter located_datasets by candidate_datasets_cte
+datasets_by_location_w_ordinality = """
+WITH fill AS ({fill_query}),
+with_parents AS (
+  SELECT fill_index, ARRAY[{parents_array}] parents FROM fill GROUP BY fill_index
+),
+{candidate_datasets_cte}
+located_datasets AS (
+  SELECT DISTINCT(id) FROM (
+    SELECT dataset_id id FROM h3_data JOIN with_parents ON h3_index = ANY(parents)
+    UNION ALL
+    SELECT dataset_id id FROM h3_children_indicators JOIN fill ON h3_index = fill_index
+  ) parent_children_datasets
+)
+SELECT * FROM (
+  SELECT
+    id,
+    name,
+    ST_AsEWKT(bbox) bbox,
+    source_org,
+    regexp_replace(description, '\n', '\n', 'g') description,
+    files,
+    url,
+    accessibility,
+    date_start,
+    date_end
+  FROM datasets JOIN located_datasets USING (id)
+) unfiltered
+JOIN candidate_datasets USING (id)
+ORDER BY ordinality
 """
 
 def get_datasets_by_location_query(resolution: int, candidate_datasets_cte=None, has_ordinality=False) -> str:
     from app.services import build_h3_parents_expression
 
-    # jerryrig
-    candidate_datasets_join = ""
-    if candidate_datasets_cte:
-        candidate_datasets_join = "JOIN candidate_datasets USING (id)"
-        if has_ordinality:
-            candidate_datasets_join += " ORDER BY ordinality"
-    return datasets_by_location.format(
+    q = datasets_by_location_w_ordinality if has_ordinality else datasets_by_location
+    return q.format(
         fill_query=location_fill_res2 if resolution == 2 else location_fill,
         parents_array=build_h3_parents_expression(resolution),
         candidate_datasets_cte=candidate_datasets_cte or "",
-        candidate_datasets_join=candidate_datasets_join
     )

--- a/api/app/sql/datasets_by_location.py
+++ b/api/app/sql/datasets_by_location.py
@@ -1,5 +1,3 @@
-from app.services import build_h3_parents_expression
-
 _bounds_query = "SELECT ST_GeomFromGeoJSON(CAST(:location AS TEXT)) bounds"
 
 # TODO: make this less redundant
@@ -47,6 +45,8 @@ FROM datasets JOIN located_datasets USING (id)
 """
 
 def get_datasets_by_location_query(resolution: int, candidate_datasets_cte=None, has_ordinality=False) -> str:
+    from app.services import build_h3_parents_expression
+
     # jerryrig
     candidate_datasets_join = ""
     if candidate_datasets_cte:

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -1,7 +1,16 @@
 steps:
 # Build the container image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/worldex-repo/worldex-api:$COMMIT_SHA', '.']
+  args: [
+    'build',
+    '-t',
+    'us-central1-docker.pkg.dev/$PROJECT_ID/worldex-repo/worldex-api:$COMMIT_SHA',
+    '-t',
+    'us-central1-docker.pkg.dev/$PROJECT_ID/worldex-repo/worldex-api:latest',
+    '--cache-from',
+    'us-central1-docker.pkg.dev/$PROJECT_ID/worldex-repo/worldex-api:latest',
+    '.'
+  ]
   dir: 'api/'
 # Push the container image to Container Registry
 - name: 'gcr.io/cloud-builders/docker'

--- a/api/scripts/es_index_datasets.py
+++ b/api/scripts/es_index_datasets.py
@@ -48,7 +48,6 @@ def main():
         ))
         for idx, row in enumerate(result):
             dataset = row._mapping
-            print(type(dataset["bbox"]), dataset["bbox"])
             doc = DatasetDocument(
                 pg_id = dataset["id"],
                 uid = dataset["uid"],
@@ -65,7 +64,6 @@ def main():
                 properties = dataset["properties"],
                 bbox = dataset["bbox"],
             )
-            print(doc)
             doc.save()
             if (idx > 0 and idx % 100 == 0):
                 print(f"{idx} documents indexed")

--- a/api/scripts/es_index_datasets.py
+++ b/api/scripts/es_index_datasets.py
@@ -1,10 +1,11 @@
+import json
 import os
 import sys
 
 from app.document import Dataset as DatasetDocument
 from app.models import Dataset
 from elasticsearch_dsl import connections
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, text
 from sqlalchemy.orm import sessionmaker
 
 DATABASE_CONNECTION = os.getenv("DATABASE_URL_SYNC")
@@ -25,24 +26,46 @@ def main():
     DatasetDocument.init()
 
     with Session() as sess:
-        result = sess.execute(select(Dataset))
-        for idx, r in enumerate(result):
-            dataset = r[0]
+        result = sess.execute(text(
+            """
+            SELECT
+                id,
+                uid,
+                name,
+                source_org,
+                last_fetched,
+                date_start,
+                date_end,
+                url,
+                files,
+                accessibility,
+                description,
+                projection,
+                properties,
+                ST_AsText(bbox) bbox
+            FROM datasets;
+            """
+        ))
+        for idx, row in enumerate(result):
+            dataset = row._mapping
+            print(type(dataset["bbox"]), dataset["bbox"])
             doc = DatasetDocument(
-                pg_id = dataset.id,
-                uid = dataset.uid,
-                name = dataset.name,
-                source_org = dataset.source_org,
-                last_fetched = dataset.last_fetched,
-                date_start = dataset.date_start,
-                date_end = dataset.date_end,
-                url = dataset.url,
-                files = dataset.files,
-                accessibility = dataset.accessibility,
-                description = dataset.description,
-                projection = dataset.projection,
-                properties = dataset.properties,
+                pg_id = dataset["id"],
+                uid = dataset["uid"],
+                name = dataset["name"],
+                source_org = dataset["source_org"],
+                last_fetched = dataset["last_fetched"],
+                date_start = dataset["date_start"],
+                date_end = dataset["date_end"],
+                url = dataset["url"],
+                files = dataset["files"],
+                accessibility = dataset["accessibility"],
+                description = dataset["description"],
+                projection = dataset["projection"],
+                properties = dataset["properties"],
+                bbox = dataset["bbox"],
             )
+            print(doc)
             doc.save()
             if (idx > 0 and idx % 100 == 0):
                 print(f"{idx} documents indexed")

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,6 +47,7 @@
     "@types/react-redux": "^7.1.25",
     "@vitejs/plugin-react": "^4.0.4",
     "autoprefixer": "^10.4.15",
+    "axios": "^1.7.2",
     "classnames": "^2.5.1",
     "date-fns": "^3.0.1",
     "deck.gl": "^8.9.23",

--- a/ui/src/components/common/LocationSearch.tsx
+++ b/ui/src/components/common/LocationSearch.tsx
@@ -6,7 +6,7 @@ import { multiPolygon, point, polygon } from "@turf/helpers";
 import { cellToLatLng, getResolution } from "h3-js";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { setFilteredDatasets, setLastZoom, setLocation, setPendingLocationCheck } from 'store/searchSlice';
+import { setLastZoom, setLocation, setPendingLocationCheck } from 'store/searchSlice';
 import { setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 import { RootState } from "store/store";
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
@@ -64,7 +64,7 @@ const LocationSearch = ({ className }: { className?: string }) => {
     });
     const datasetsResults = await datasetsResp.json();
     if (datasetsResults) {
-      dispatch(setFilteredDatasets(datasetsResults));
+      // dispatch(setFilteredDatasets(datasetsResults));
     }
 
     dispatch(setPendingLocationCheck(true));
@@ -118,7 +118,7 @@ const LocationSearch = ({ className }: { className?: string }) => {
     setOptions([]);
     dispatch(setLocation(null));
     dispatch(setLastZoom(null));
-    dispatch(setFilteredDatasets(null));
+    // dispatch(setFilteredDatasets(null));
   }
 
   useEffect(() => {

--- a/ui/src/components/common/LocationSearch.tsx
+++ b/ui/src/components/common/LocationSearch.tsx
@@ -6,7 +6,7 @@ import { multiPolygon, point, polygon } from "@turf/helpers";
 import { cellToLatLng, getResolution } from "h3-js";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { setFilteredDatasets, setLastZoom, setLocation, setPendingLocationCheck } from 'store/locationSlice';
+import { setFilteredDatasets, setLastZoom, setLocation, setPendingLocationCheck } from 'store/searchSlice';
 import { setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 import { RootState } from "store/store";
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
@@ -43,7 +43,7 @@ const LocationSearch = ({ className }: { className?: string }) => {
   const dispatch = useDispatch();
   const { h3Index: selectedH3Index }: { h3Index: string } = useSelector((state: RootState) => state.selected);
   const viewState = useSelector((state: RootState) => state.carto.viewState);
-  const { location, lastZoom } = useSelector((state: RootState) => state.location);
+  const { location, lastZoom } = useSelector((state: RootState) => state.search);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
   const accessibilities = useSelector(selectAccessibilities);
 

--- a/ui/src/components/common/ZoomControl.tsx
+++ b/ui/src/components/common/ZoomControl.tsx
@@ -7,7 +7,7 @@ import RemoveOutlinedIcon from '@mui/icons-material/RemoveOutlined';
 import { setViewState } from '@carto/react-redux';
 import { RootState } from 'store/store';
 import { MAXIMUM_ZOOM, MINIMUM_ZOOM } from 'constants/h3';
-import { setPendingLocationCheck } from 'store/locationSlice';
+import { setPendingLocationCheck } from 'store/searchSlice';
 
 const GridZoomControl = styled(Grid)(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,

--- a/ui/src/components/common/map/useMapHooks.tsx
+++ b/ui/src/components/common/map/useMapHooks.tsx
@@ -6,7 +6,7 @@ import { Typography } from '@carto/react-ui';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { debounce } from '@mui/material';
 import { MAXIMUM_ZOOM, MINIMUM_ZOOM } from 'constants/h3';
-import { setPendingLocationCheck } from 'store/locationSlice';
+import { setPendingLocationCheck } from 'store/searchSlice';
 import { RootState } from 'store/store';
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
 import { setSteppedZoom } from 'store/appSlice';
@@ -37,7 +37,7 @@ export function useMapHooks() {
   const dispatch = useDispatch();
 
   let isHovering = false;
-  const { pendingLocationCheck } = useSelector((state: RootState) => state.location);
+  const { pendingLocationCheck } = useSelector((state: RootState) => state.search);
 
   const handleViewStateChange = ({ viewState }: { viewState: ViewState }) => {
     if (viewState.zoom != null) {

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -85,11 +85,19 @@ const Content = () => {
       <Divider />
       <div className="px-4 py-3.5">
         <Typography className="text-md font-bold">
-          <span>
-            Total datasets indexed
-            { isFiltered && ' (filtered)' }:{' '}
-          </span>
-          <span className="text-lg">{ datasets ? datasets.length : datasetCount}</span>
+          {
+            (Array.isArray(datasets) && datasets.length > 0) ? (
+              <>
+                <span>Filtered datasets: </span>
+                <span className="text-lg">{ datasets.length }</span>
+              </>
+            ) : (
+              <>
+                <span>Total datasets: </span>
+                <span className="text-lg">{ datasetCount }</span>
+              </>
+            )
+          }
         </Typography>
         {
           location?.display_name && (<span className="text-xs italic">{location.display_name}</span>)

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -20,20 +20,18 @@ const Content = () => {
   const { h3Index, datasets: datasets_ }: { h3Index: string, datasets: Dataset[] } = useSelector((state: RootState) => state.selected);
   const { location }: { location: any } = useSelector((state: RootState) => state.search);
   const { h3IndexedDatasets } : { h3IndexedDatasets: Dataset[] } = useSelector((state: RootState) => state.selectedFilters);
-  // const datasets = h3Index ? datasets_ : filteredDatasets;
+  const { datasetIds }: { datasetIds: number[] } = useSelector((state: RootState) => state.selectedFilters);
   const datasets = h3Index ? h3IndexedDatasets : datasets_;
-  // const datasetsByOrgs = datasets ? groupBy(datasets, "source_org") : null;
 
   const { h3Index: selectedH3Index } = useSelector((state: RootState) => state.selected);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
   const accessibilities = useSelector(selectAccessibilities);
-  const { filteredDatasets: locationFilteredDatasets }: { filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.search);
   const { datasetCount }: { datasetCount: number } = useSelector((state: RootState) => state.selected);
   const { selectedDataset } = useSelector((state: RootState) => state.selected);
   const { fileUrl: previewFileUrl, isLoadingPreview } = useSelector((state: RootState) => state.preview);
 
   const isFiltered = (
-    locationFilteredDatasets
+    (Array.isArray(datasetIds) && datasetIds.length > 0)
     || (Array.isArray(sourceOrgs) && sourceOrgs.length > 0)
     || (Array.isArray(accessibilities) && accessibilities.length > 0)
   )
@@ -85,19 +83,12 @@ const Content = () => {
       <Divider />
       <div className="px-4 py-3.5">
         <Typography className="text-md font-bold">
-          {
-            (Array.isArray(datasets) && datasets.length > 0) ? (
-              <>
-                <span>Filtered datasets: </span>
-                <span className="text-lg">{ datasets.length }</span>
-              </>
-            ) : (
-              <>
-                <span>Total datasets: </span>
-                <span className="text-lg">{ datasetCount }</span>
-              </>
-            )
-          }
+          <span>
+            { selectedH3Index ? `Tile ${selectedH3Index} datasets` : `Total datasets`}
+            { isFiltered ? ' (filtered)' : ''}
+            {": "}
+            { datasets.length || datasetCount }
+          </span>
         </Typography>
         {
           location?.display_name && (<span className="text-xs italic">{location.display_name}</span>)

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -107,7 +107,7 @@ const Content = () => {
         }
       </div>
       <Divider />
-      { datasetsByOrgs && <Datasets header={header} datasetsByOrgs={datasetsByOrgs} /> }
+      { datasets && <Datasets datasets={datasets} /> }
     </div>
   );
 };

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -21,10 +21,7 @@ const Content = () => {
   const { location, filteredDatasets }: { location: any, filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.search);
   // const datasets = h3Index ? datasets_ : filteredDatasets;
   const datasets = datasets_;
-  console.log(datasets_);
   const datasetsByOrgs = datasets ? groupBy(datasets, "source_org") : null;
-  // const header = h3Index ? 'Tile Datasets' : `${location?.name} Datasets`;
-  const header = 'Datasets';
 
   const { h3Index: selectedH3Index } = useSelector((state: RootState) => state.selected);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
@@ -79,12 +76,9 @@ const Content = () => {
     });
   }, [sourceOrgs, accessibilities]);
 
-  console.log(datasetsByOrgs);
   return (
     <div className="h-full">
       <Search className="p-3" />
-      {/* <Divider /> */}
-      {/* { h3Index ? <Selected /> : <Overview /> } */}
       <Divider />
       <Filters className="p-4 pb-6" />
       <Divider />
@@ -94,12 +88,14 @@ const Content = () => {
             Total datasets indexed
             { isFiltered && ' (filtered)' }:{' '}
           </span>
-          {/* <span className="text-lg">{locationFilteredDatasets ? locationFilteredDatasets.length : datasetCount}</span> */}
           <span className="text-lg">{ datasets ? datasets.length : datasetCount}</span>
         </Typography>
         {
+          location?.display_name && (<span className="text-xs italic">{location.display_name}</span>)
+        }
+        {
           (selectedDataset || selectedH3Index || (previewFileUrl && !isLoadingPreview)) ? (
-            <div className="flex justify-start mt-3.5">
+            <div className="flex justify-start mt-1">
               { selectedDataset && <DeselectDatasetButton className="p-0 leading-4 first:text-left" /> }
               { selectedH3Index && <DeselectTileButton className="p-0 leading-4 first:text-left last:text-right" /> }
               { (previewFileUrl && !isLoadingPreview) && <HidePreviewButton className="p-0 leading-4 first:text-left last:text-right" /> }

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -18,7 +18,7 @@ import HidePreviewButton from "./HidePreviewButton";
 
 const Content = () => {
   const { h3Index, datasets: datasets_ }: { h3Index: string, datasets: Dataset[] } = useSelector((state: RootState) => state.selected);
-  const { location, filteredDatasets }: { location: any, filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.location);
+  const { location, filteredDatasets }: { location: any, filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.search);
   // const datasets = h3Index ? datasets_ : filteredDatasets;
   const datasets = datasets_;
   console.log(datasets_);
@@ -29,7 +29,7 @@ const Content = () => {
   const { h3Index: selectedH3Index } = useSelector((state: RootState) => state.selected);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
   const accessibilities = useSelector(selectAccessibilities);
-  const { filteredDatasets: locationFilteredDatasets }: { filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.location);
+  const { filteredDatasets: locationFilteredDatasets }: { filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.search);
   const { datasetCount }: { datasetCount: number } = useSelector((state: RootState) => state.selected);
   const { selectedDataset } = useSelector((state: RootState) => state.selected);
   const { fileUrl: previewFileUrl, isLoadingPreview } = useSelector((state: RootState) => state.preview);
@@ -94,7 +94,8 @@ const Content = () => {
             Total datasets indexed
             { isFiltered && ' (filtered)' }:{' '}
           </span>
-          <span className="text-lg">{locationFilteredDatasets ? locationFilteredDatasets.length : datasetCount}</span>
+          {/* <span className="text-lg">{locationFilteredDatasets ? locationFilteredDatasets.length : datasetCount}</span> */}
+          <span className="text-lg">{ datasets ? datasets.length : datasetCount}</span>
         </Typography>
         {
           (selectedDataset || selectedH3Index || (previewFileUrl && !isLoadingPreview)) ? (

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -1,4 +1,4 @@
-import { Divider } from "@mui/material";
+import { Divider, Typography } from "@mui/material";
 import Filters from "components/filters/Filters";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "store/store";
@@ -9,19 +9,36 @@ import Overview from "./Overview";
 import Selected from "./Selected";
 import { selectAccessibilities, selectSourceOrgFilters } from "store/selectedFiltersSlice";
 import { useEffect } from "react";
-import { setDatasets } from "store/selectedSlice";
+import { setDatasetCount, setDatasets } from "store/selectedSlice";
+import Search from "components/search/Search";
+import DeselectDatasetButton from "./DeselectDatasetButton";
+import DeselectTileButton from "./DeselectTileButton";
+import HidePreviewButton from "./HidePreviewButton";
 
 
 const Content = () => {
   const { h3Index, datasets: datasets_ }: { h3Index: string, datasets: Dataset[] } = useSelector((state: RootState) => state.selected);
   const { location, filteredDatasets }: { location: any, filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.location);
-  const datasets = h3Index ? datasets_ : filteredDatasets;
+  // const datasets = h3Index ? datasets_ : filteredDatasets;
+  const datasets = datasets_;
+  console.log(datasets_);
   const datasetsByOrgs = datasets ? groupBy(datasets, "source_org") : null;
-  const header = h3Index ? 'Tile Datasets' : `${location?.name} Datasets`;
+  // const header = h3Index ? 'Tile Datasets' : `${location?.name} Datasets`;
+  const header = 'Datasets';
 
   const { h3Index: selectedH3Index } = useSelector((state: RootState) => state.selected);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
   const accessibilities = useSelector(selectAccessibilities);
+  const { filteredDatasets: locationFilteredDatasets }: { filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.location);
+  const { datasetCount }: { datasetCount: number } = useSelector((state: RootState) => state.selected);
+  const { selectedDataset } = useSelector((state: RootState) => state.selected);
+  const { fileUrl: previewFileUrl, isLoadingPreview } = useSelector((state: RootState) => state.preview);
+
+  const isFiltered = (
+    locationFilteredDatasets
+    || (Array.isArray(sourceOrgs) && sourceOrgs.length > 0)
+    || (Array.isArray(accessibilities) && accessibilities.length > 0)
+  )
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -44,11 +61,51 @@ const Content = () => {
     }
   }, [selectedH3Index, sourceOrgs, accessibilities]);
 
+  useEffect(() => {
+    fetch(`${import.meta.env.VITE_API_URL}/dataset_count/`, {
+      method: 'post',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        source_org: sourceOrgs,
+        accessibility: accessibilities,
+      })
+    })
+    .then(resp => resp.json())
+    .then((data) => {
+      dispatch(setDatasetCount(data["dataset_count"]))
+    });
+  }, [sourceOrgs, accessibilities]);
+
+  console.log(datasetsByOrgs);
   return (
     <div className="h-full">
-      { h3Index ? <Selected /> : <Overview /> }
+      <Search className="p-3" />
+      {/* <Divider /> */}
+      {/* { h3Index ? <Selected /> : <Overview /> } */}
       <Divider />
       <Filters className="p-4 pb-6" />
+      <Divider />
+      <div className="px-4 py-3.5">
+        <Typography className="text-md font-bold">
+          <span>
+            Total datasets indexed
+            { isFiltered && ' (filtered)' }:{' '}
+          </span>
+          <span className="text-lg">{locationFilteredDatasets ? locationFilteredDatasets.length : datasetCount}</span>
+        </Typography>
+        {
+          (selectedDataset || selectedH3Index || (previewFileUrl && !isLoadingPreview)) ? (
+            <div className="flex justify-start mt-3.5">
+              { selectedDataset && <DeselectDatasetButton className="p-0 leading-4 first:text-left" /> }
+              { selectedH3Index && <DeselectTileButton className="p-0 leading-4 first:text-left last:text-right" /> }
+              { (previewFileUrl && !isLoadingPreview) && <HidePreviewButton className="p-0 leading-4 first:text-left last:text-right" /> }
+            </div>
+          ) : null
+        }
+      </div>
       <Divider />
       { datasetsByOrgs && <Datasets header={header} datasetsByOrgs={datasetsByOrgs} /> }
     </div>

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -48,6 +48,7 @@ const Content = () => {
         body: JSON.stringify({
           source_org: sourceOrgs,
           accessibility: accessibilities,
+          dataset_ids: datasetIds,
         }),
       })
       .then((resp: Response) => resp.json())

--- a/ui/src/components/common/sidebar/Content.tsx
+++ b/ui/src/components/common/sidebar/Content.tsx
@@ -7,7 +7,7 @@ import { Dataset } from "../types";
 import Datasets from "./Datasets";
 import Overview from "./Overview";
 import Selected from "./Selected";
-import { selectAccessibilities, selectSourceOrgFilters } from "store/selectedFiltersSlice";
+import { selectAccessibilities, selectSourceOrgFilters, setH3IndexedDatasets } from "store/selectedFiltersSlice";
 import { useEffect } from "react";
 import { setDatasetCount, setDatasets } from "store/selectedSlice";
 import Search from "components/search/Search";
@@ -18,10 +18,11 @@ import HidePreviewButton from "./HidePreviewButton";
 
 const Content = () => {
   const { h3Index, datasets: datasets_ }: { h3Index: string, datasets: Dataset[] } = useSelector((state: RootState) => state.selected);
-  const { location, filteredDatasets }: { location: any, filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.search);
+  const { location }: { location: any } = useSelector((state: RootState) => state.search);
+  const { h3IndexedDatasets } : { h3IndexedDatasets: Dataset[] } = useSelector((state: RootState) => state.selectedFilters);
   // const datasets = h3Index ? datasets_ : filteredDatasets;
-  const datasets = datasets_;
-  const datasetsByOrgs = datasets ? groupBy(datasets, "source_org") : null;
+  const datasets = h3Index ? h3IndexedDatasets : datasets_;
+  // const datasetsByOrgs = datasets ? groupBy(datasets, "source_org") : null;
 
   const { h3Index: selectedH3Index } = useSelector((state: RootState) => state.selected);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
@@ -53,7 +54,7 @@ const Content = () => {
       })
       .then((resp: Response) => resp.json())
       .then((results) => {
-        dispatch(setDatasets(results));
+        dispatch(setH3IndexedDatasets(results));
       });
     }
   }, [selectedH3Index, sourceOrgs, accessibilities]);

--- a/ui/src/components/common/sidebar/Datasets.tsx
+++ b/ui/src/components/common/sidebar/Datasets.tsx
@@ -14,7 +14,7 @@ const DatasetItem = ({idx, dataset}: {idx: number, dataset: Dataset}) => {
   const [anchor, setAnchor] = useState(null);
   const { selectedDataset } = useSelector((state: RootState) => state.selected);
   const viewState = useSelector((state: RootState) => state.carto.viewState);
-  const { location } = useSelector((state: RootState) => state.location);
+  const { location } = useSelector((state: RootState) => state.search);
   const dispatch = useDispatch();
   const toggleVisibility = (datasetId: number, bbox: BoundingBox) => {
     if (anchor) {

--- a/ui/src/components/common/sidebar/Datasets.tsx
+++ b/ui/src/components/common/sidebar/Datasets.tsx
@@ -89,12 +89,6 @@ const Datasets = ({ datasets }: { datasets: Dataset[] }) => {
 // TODO: rm component
 const DatasetsByOrgs = ({ datasetsByOrgs, header }: { datasetsByOrgs: { [source_org: string]: Dataset[]; }, header?: string }) => (
   <div>
-    {/* { header && (
-      <>
-        <Typography className="px-4 py-3.5 font-bold">{header}</Typography>
-        <Divider />
-      </>
-    )} */}
     {
       Object.entries(datasetsByOrgs).map(([org, datasets]) => (
         <Accordion

--- a/ui/src/components/common/sidebar/Datasets.tsx
+++ b/ui/src/components/common/sidebar/Datasets.tsx
@@ -65,14 +65,15 @@ const DatasetItem = ({idx, dataset}: {idx: number, dataset: Dataset}) => {
   )
 }
 
+// TODO: rm header from code
 const Datasets = ({ datasetsByOrgs, header }: { datasetsByOrgs: { [source_org: string]: Dataset[]; }, header?: string }) => (
   <div>
-    { header && (
+    {/* { header && (
       <>
         <Typography className="px-4 py-3.5 font-bold">{header}</Typography>
         <Divider />
       </>
-    )}
+    )} */}
     {
       Object.entries(datasetsByOrgs).map(([org, datasets]) => (
         <Accordion

--- a/ui/src/components/common/sidebar/Datasets.tsx
+++ b/ui/src/components/common/sidebar/Datasets.tsx
@@ -65,8 +65,29 @@ const DatasetItem = ({idx, dataset}: {idx: number, dataset: Dataset}) => {
   )
 }
 
-// TODO: rm header from code
-const Datasets = ({ datasetsByOrgs, header }: { datasetsByOrgs: { [source_org: string]: Dataset[]; }, header?: string }) => (
+const Datasets = ({ datasets }: { datasets: Dataset[] }) => {
+  return (
+    <List className="m-0 p-0 max-h-[60vh] overflow-y-scroll">
+      {
+        datasets.map((dataset: Dataset, idx: number) => (
+            <ListItem
+              key={idx}
+              className="p-0"
+            >
+              {/* TODO: consider semantic usage of ListItemX components */}
+              <Stack direction="column" className="w-full">
+                <DatasetItem idx={idx} dataset={dataset} />
+                {idx + 1 < datasets.length && <Divider />}
+              </Stack>
+            </ListItem>
+        ))
+      }
+    </List>
+  );
+};
+
+// TODO: rm component
+const DatasetsByOrgs = ({ datasetsByOrgs, header }: { datasetsByOrgs: { [source_org: string]: Dataset[]; }, header?: string }) => (
   <div>
     {/* { header && (
       <>

--- a/ui/src/components/common/sidebar/DeselectDatasetButton.tsx
+++ b/ui/src/components/common/sidebar/DeselectDatasetButton.tsx
@@ -2,13 +2,13 @@ import { Button } from "@mui/material";
 import { useDispatch } from "react-redux"
 import { setSelectedDataset } from "store/selectedSlice";
 
-const DeselectDatasetButton = () => {
+const DeselectDatasetButton = ({ className }: { className?: string }) => {
   const dispatch = useDispatch();
   return (
-    <Button 
+    <Button
       size="small"
       variant="text"
-      className="uppercase mt-1 p-0 hover:bg-transparent"
+      className={`uppercase hover:bg-transparent ${className}`}
       onClick={() => {
         dispatch(setSelectedDataset(null));
       }}

--- a/ui/src/components/common/sidebar/DeselectTileButton.tsx
+++ b/ui/src/components/common/sidebar/DeselectTileButton.tsx
@@ -12,7 +12,6 @@ const DeselectTileButton = ({ className }: { className?: string }) => {
       className={`uppercase hover:bg-transparent ${className}`}
       onClick={() => {
         dispatch(setSelectedH3Index(null));
-        // TODO: reset dataset to previous state instead
         dispatch(setH3IndexedDatasets([]));
       }}
     >

--- a/ui/src/components/common/sidebar/DeselectTileButton.tsx
+++ b/ui/src/components/common/sidebar/DeselectTileButton.tsx
@@ -1,0 +1,22 @@
+import { Button } from "@mui/material";
+import { useDispatch } from "react-redux";
+import { setDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+
+const DeselectTileButton = ({ className }: { className?: string }) => {
+  const dispatch = useDispatch();
+  return (
+    <Button
+      size="small"
+      variant="text"
+      className={`uppercase hover:bg-transparent ${className}`}
+      onClick={() => {
+        dispatch(setSelectedH3Index(null));
+        dispatch(setDatasets(null));
+      }}
+    >
+      Deselect tile
+    </Button>
+  )
+}
+
+export default DeselectTileButton;

--- a/ui/src/components/common/sidebar/DeselectTileButton.tsx
+++ b/ui/src/components/common/sidebar/DeselectTileButton.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@mui/material";
 import { useDispatch } from "react-redux";
-import { resetDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { setH3IndexedDatasets } from "store/selectedFiltersSlice";
+import { setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 
 const DeselectTileButton = ({ className }: { className?: string }) => {
   const dispatch = useDispatch();
@@ -11,7 +12,8 @@ const DeselectTileButton = ({ className }: { className?: string }) => {
       className={`uppercase hover:bg-transparent ${className}`}
       onClick={() => {
         dispatch(setSelectedH3Index(null));
-        dispatch(resetDatasets());
+        // TODO: reset dataset to previous state instead
+        dispatch(setH3IndexedDatasets([]));
       }}
     >
       Deselect tile

--- a/ui/src/components/common/sidebar/DeselectTileButton.tsx
+++ b/ui/src/components/common/sidebar/DeselectTileButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@mui/material";
 import { useDispatch } from "react-redux";
-import { setDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { resetDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 
 const DeselectTileButton = ({ className }: { className?: string }) => {
   const dispatch = useDispatch();
@@ -11,7 +11,7 @@ const DeselectTileButton = ({ className }: { className?: string }) => {
       className={`uppercase hover:bg-transparent ${className}`}
       onClick={() => {
         dispatch(setSelectedH3Index(null));
-        dispatch(setDatasets(null));
+        dispatch(resetDatasets());
       }}
     >
       Deselect tile

--- a/ui/src/components/common/sidebar/HidePreviewButton.tsx
+++ b/ui/src/components/common/sidebar/HidePreviewButton.tsx
@@ -2,13 +2,13 @@ import { Button } from "@mui/material";
 import { useDispatch } from "react-redux"
 import { setFileUrl } from "store/previewSlice";
 
-const HidePreviewButton = () => {
+const HidePreviewButton = ({ className }: { className?: string }) => {
   const dispatch = useDispatch();
   return (
     <Button
       size="small"
       variant="text"
-      className="uppercase mt-1 p-0 hover:bg-transparent"
+      className={`uppercase hover:bg-transparent ${className}`}
       onClick={() => {
         dispatch(setFileUrl(null));
       }}

--- a/ui/src/components/common/sidebar/Overview.tsx
+++ b/ui/src/components/common/sidebar/Overview.tsx
@@ -8,6 +8,7 @@ import HidePreviewButton from "./HidePreviewButton";
 import { selectAccessibilities, selectSourceOrgFilters } from "store/selectedFiltersSlice";
 import { Dataset } from "../types";
 
+// TODO: repurpose as diagnostics component
 const Overview = () => {
   const { datasetCount }: { datasetCount: number } = useSelector((state: RootState) => state.selected);
   const dispatch = useDispatch();

--- a/ui/src/components/common/sidebar/Overview.tsx
+++ b/ui/src/components/common/sidebar/Overview.tsx
@@ -48,7 +48,7 @@ const Overview = () => {
       <Typography className="text-md font-bold">
         <span>
           Total datasets indexed
-          { isFiltered && ' (filtered)' }:{' '}
+          { isFiltered && locationFilteredDatasets.length && ' (filtered)' }:{' '}
         </span>
         <span className="text-lg">{locationFilteredDatasets ? locationFilteredDatasets.length : datasetCount}</span>
       </Typography>

--- a/ui/src/components/common/sidebar/Overview.tsx
+++ b/ui/src/components/common/sidebar/Overview.tsx
@@ -18,7 +18,7 @@ const Overview = () => {
   const { fileUrl: previewFileUrl, isLoadingPreview } = useSelector((state: RootState) => state.preview);
   const sourceOrgs = useSelector(selectSourceOrgFilters);
   const accessibilities = useSelector(selectAccessibilities);
-  const { filteredDatasets: locationFilteredDatasets }: { filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.location);
+  const { filteredDatasets: locationFilteredDatasets }: { filteredDatasets: Dataset[] } = useSelector((state: RootState) => state.search);
   const isFiltered = (
     locationFilteredDatasets
     || (Array.isArray(sourceOrgs) && sourceOrgs.length > 0)

--- a/ui/src/components/common/sidebar/Selected.tsx
+++ b/ui/src/components/common/sidebar/Selected.tsx
@@ -1,7 +1,7 @@
 import { Button, Stack, Typography } from "@mui/material";
 import { UNITS, cellArea, getResolution } from "h3-js";
 import { useDispatch, useSelector } from "react-redux";
-import { setDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { resetDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 import { RootState } from "store/store";
 import { Dataset } from "../types";
 import DeselectDatasetButton from "./DeselectDatasetButton";
@@ -14,7 +14,7 @@ const Selected = () => {
   const dispatch = useDispatch();
   const handleDeselectClick = () => {
     dispatch(setSelectedH3Index(null));
-    dispatch(setDatasets(null));
+    dispatch(resetDatasets());
   }
 
   return (

--- a/ui/src/components/common/sidebar/Selected.tsx
+++ b/ui/src/components/common/sidebar/Selected.tsx
@@ -1,7 +1,7 @@
 import { Button, Stack, Typography } from "@mui/material";
 import { UNITS, cellArea, getResolution } from "h3-js";
 import { useDispatch, useSelector } from "react-redux";
-import { resetDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { resetByKey as resetSelectedByKey, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 import { RootState } from "store/store";
 import { Dataset } from "../types";
 import DeselectDatasetButton from "./DeselectDatasetButton";
@@ -14,7 +14,7 @@ const Selected = () => {
   const dispatch = useDispatch();
   const handleDeselectClick = () => {
     dispatch(setSelectedH3Index(null));
-    dispatch(resetDatasets());
+    dispatch(resetSelectedByKey('h3Index', 'datasets'));
   }
 
   return (

--- a/ui/src/components/filters/Filters.tsx
+++ b/ui/src/components/filters/Filters.tsx
@@ -7,7 +7,7 @@ function Filters({ className }: { className?: string }) {
   return (
     <div className={className}>
       <div className="mb-2 flex items-center justify-between">
-        <Typography className="font-bold">Search Filters</Typography>
+        <Typography className="font-bold">Filters</Typography>
         <ClearFiltersButton className="mr-2" />
       </div>
       <div>

--- a/ui/src/components/layers/DatasetCountLayer.tsx
+++ b/ui/src/components/layers/DatasetCountLayer.tsx
@@ -84,7 +84,7 @@ export default function DatasetCountLayer() {
   const source = useSelector((state: RootState) => selectSourceById(state, datasetH3Layer?.source));
   const { selectedDataset, h3Index: selectedH3Index } = useSelector((state: RootState) => state.selected);
   const { steppedZoom } = useSelector((state: RootState) => state.app);
-  const { location } = useSelector((state: RootState) => state.location);
+  const { location } = useSelector((state: RootState) => state.search);
   const { fileUrl } = useSelector((state: RootState) => state.preview);
   const dispatch = useDispatch();
   const sourceOrgs = useSelector(selectSourceOrgFilters);

--- a/ui/src/components/layers/DatasetCountLayer.tsx
+++ b/ui/src/components/layers/DatasetCountLayer.tsx
@@ -10,7 +10,7 @@ import { DatasetCount } from 'components/common/types';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectAccessibilities, selectSourceOrgFilters } from 'store/selectedFiltersSlice';
-import { setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { resetByKey as resetSelectedByKeys, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 import { RootState } from 'store/store';
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
 import {
@@ -144,9 +144,7 @@ export default function DatasetCountLayer() {
       onClick: async (info: any, event: object) => {
         const targetIndex = info.object.index;
         if (selectedH3Index === targetIndex) {
-          dispatch(setSelectedH3Index(null));
-          // should have dedicated datasets for selected?
-          // dispatch(resetDatasets());
+          dispatch(resetSelectedByKeys('h3Index'));
           return;
         }
         dispatch(setSelectedH3Index(targetIndex));

--- a/ui/src/components/layers/DatasetCountLayer.tsx
+++ b/ui/src/components/layers/DatasetCountLayer.tsx
@@ -1,25 +1,24 @@
 import { OR_YEL, SELECTED_OUTLINE } from 'constants/colors';
-import { selectSourceById } from '@carto/react-redux';
-import { useDispatch, useSelector } from 'react-redux';
-import { H3HexagonLayer, TileLayer } from '@deck.gl/geo-layers/typed';
-import { TileLoadProps, Tile2DHeader } from '@deck.gl/geo-layers/typed/tileset-2d';
-import { Typography } from '@mui/material';
-import { Dataset, DatasetCount } from 'components/common/types';
-import { renderToStaticMarkup } from 'react-dom/server';
-import { setDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
-import { RootState } from 'store/store';
 import { colorBins, hexToRgb } from 'utils/colors';
+import { selectSourceById } from '@carto/react-redux';
+import { H3HexagonLayer, TileLayer } from '@deck.gl/geo-layers/typed';
+import { Tile2DHeader, TileLoadProps } from '@deck.gl/geo-layers/typed/tileset-2d';
+import { ArrowLoader } from '@loaders.gl/arrow';
+import { load } from '@loaders.gl/core';
+import { Typography } from '@mui/material';
+import { DatasetCount } from 'components/common/types';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectAccessibilities, selectSourceOrgFilters } from 'store/selectedFiltersSlice';
+import { setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { RootState } from 'store/store';
+import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
 import {
   TILE_STATE_VISIBLE,
   TILE_STATE_VISITED,
   getPlaceholderInAncestors,
   getPlaceholderInChildren,
 } from 'utils/tileRefinement';
-import { load } from '@loaders.gl/core';
-import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
-import { ArrowLoader } from '@loaders.gl/arrow';
-import { selectAccessibilities, selectSourceOrgFilters } from 'store/selectedFiltersSlice';
-import { useEffect } from 'react';
 
 export const DATASET_COUNT_LAYER_ID = 'datasetCountLayer';
 
@@ -89,6 +88,7 @@ export default function DatasetCountLayer() {
   const dispatch = useDispatch();
   const sourceOrgs = useSelector(selectSourceOrgFilters);
   const accessibilities = useSelector(selectAccessibilities);
+  const { datasetIds } = useSelector((state: RootState) => state.selectedFilters);
 
   const domains = (import.meta.env.VITE_DATASET_COUNT_BINS).split(',').map(Number);
   const getColor = colorBins({
@@ -126,6 +126,7 @@ export default function DatasetCountLayer() {
                   ? JSON.stringify(location.geojson)
                   : null
               ),
+              dataset_ids: datasetIds,
               source_org: sourceOrgs,
               accessibility: accessibilities,
             }),
@@ -144,7 +145,8 @@ export default function DatasetCountLayer() {
         const targetIndex = info.object.index;
         if (selectedH3Index === targetIndex) {
           dispatch(setSelectedH3Index(null));
-          dispatch(setDatasets(null));
+          // should have dedicated datasets for selected?
+          // dispatch(resetDatasets());
           return;
         }
         dispatch(setSelectedH3Index(targetIndex));
@@ -209,7 +211,7 @@ export default function DatasetCountLayer() {
         getLineColor: [selectedH3Index, shouldDim],
         getFillColor: [selectedH3Index, shouldDim],
         getLineWidth: [selectedH3Index, shouldDim],
-        getTileData: [sourceOrgs, accessibilities],
+        getTileData: [sourceOrgs, accessibilities, datasetIds],
       },
     });
   }

--- a/ui/src/components/layers/DatasetCoverageLayer.tsx
+++ b/ui/src/components/layers/DatasetCoverageLayer.tsx
@@ -7,7 +7,7 @@ import { TileLoadProps } from '@deck.gl/geo-layers/typed/tileset-2d';
 import { RootState } from 'store/store';
 import { hexToRgb } from 'utils/colors';
 import { setSelectedDataset } from 'store/selectedSlice';
-import { setPendingLocationCheck } from 'store/locationSlice';
+import { setPendingLocationCheck } from 'store/searchSlice';
 import { load } from '@loaders.gl/core';
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
 
@@ -18,7 +18,7 @@ export default function DatasetCoverageLayer() {
   const source = useSelector((state) => selectSourceById(state, datasetCoverageLayer?.source));
   const { selectedDataset } = useSelector((state: RootState) => state.selected);
   const { steppedZoom } = useSelector((state: RootState) => state.app);
-  const { location, pendingLocationCheck } = useSelector((state: RootState) => state.location);
+  const { location, pendingLocationCheck } = useSelector((state: RootState) => state.search);
   const BLUE_600 = hexToRgb(blue['600']); // #1e88e5
   const dispatch = useDispatch();
 

--- a/ui/src/components/layers/SearchLayer.tsx
+++ b/ui/src/components/layers/SearchLayer.tsx
@@ -7,7 +7,7 @@ export const SEARCH_LAYER_ID = 'searchLayer';
 
 export default function SearchLayer() {
   const { searchLayer } = useSelector((state: RootState) => state.carto.layers);
-  const { location } = useSelector((state: RootState) => state.location);
+  const { location } = useSelector((state: RootState) => state.search);
   const data = location?.geojson;
 
   if (searchLayer && data) {

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -233,6 +233,7 @@ function Search({ className }: { className?: string }) {
     let candidateDatasets;
     let params = keywordPayload;
     if (location.skip) {
+      console.log('skipping');
       let keywordQ;
       if (hasNoEntities) {
         keywordQ = query;
@@ -251,6 +252,7 @@ function Search({ className }: { className?: string }) {
       candidateDatasets = hits;
       fetched = true;
     } else {
+      console.log(hasStatIndicator);
       // eslint-disable-next-line no-lonely-if
       if (hasStatIndicator) {
         const { hits } = await getDatasetsByKeyword();
@@ -272,8 +274,6 @@ function Search({ className }: { className?: string }) {
         return;
       } else if (location.skip) {
         dispatch(setDatasets(candidateDatasets));
-        return;
-      } else {
         // we fly the map to the first ranked dataset
         if (candidateDatasets[0]?.bbox) {
           const [w, s, e, n] = candidateDatasets[0].bbox;

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -16,7 +16,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   setLastZoom, setLocation, setPendingLocationCheck,
 } from 'store/searchSlice';
-import { selectAccessibilities, selectSourceOrgFilters, setDatasetIds } from 'store/selectedFiltersSlice';
+import {
+  selectAccessibilities,
+  selectSourceOrgFilters,
+  setDatasetIds,
+  setH3IndexedDatasets,
+} from 'store/selectedFiltersSlice';
 import { resetDatasets, setDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
 import { RootState } from 'store/store';
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
@@ -200,6 +205,8 @@ function Search({ className }: { className?: string }) {
     dispatch(setLocation(null));
     dispatch(setLastZoom(null));
     dispatch(resetDatasets());
+    dispatch(setDatasetIds([]));
+    dispatch(setH3IndexedDatasets([]));
   };
 
   useEffect(() => {

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -99,8 +99,11 @@ function Search({ className }: { className?: string }) {
         },
       },
     );
-    if (datasetsResults) {
+    if (Array.isArray(datasetsResults) && datasetsResults.length > 0) {
       dispatch(setDatasets(datasetsResults));
+    } else {
+      setError('No dataset results');
+      return;
     }
 
     dispatch(setPendingLocationCheck(true));

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -63,7 +63,6 @@ function ClearButton() {
 
 function Search({ className }: { className?: string }) {
   const [query, setQuery] = useState('');
-  // const [strippedQuery ,setStrippedQuery] = useState('');
   const [options, setOptions] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -77,37 +76,6 @@ function Search({ className }: { className?: string }) {
   const accessibilities = useSelector(selectAccessibilities);
 
   const dispatch = useDispatch();
-
-  const onlyGetDatasets = async ({ location, zoom, candidateDatasetIds }: { location: any, zoom: number, candidateDatasetIds?: number[] }) => {
-    const [_, resolution] = getSteppedZoomResolutionPair(zoom);
-    const body: any = {
-      location: JSON.stringify(location.geojson),
-      resolution,
-    };
-    if (Array.isArray(candidateDatasetIds) && candidateDatasetIds.length > 0) {
-      body.dataset_ids = candidateDatasetIds;
-    } else {
-      body.source_org = sourceOrgs;
-      body.accessibility = accessibilities;
-    }
-    const { data } = await axios.post(
-      `${import.meta.env.VITE_API_URL}/datasets_by_location/`,
-      body,
-      {
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      },
-    );
-    return data;
-    // if (Array.isArray(datasetsResults) && datasetsResults.length > 0) {
-    //   dispatch(setDatasets(datasetsResults));
-    // } else {
-    //   setError('No dataset results');
-    //   return;
-    // }
-  };
 
   const getDatasets = async ({ location, zoom, datasetIds }: { location: any, zoom: number, datasetIds?: number[] }) => {
     // TODO: make this single purpose. lessen side effects and simply return datasets

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -1,0 +1,195 @@
+import ClearIcon from '@mui/icons-material/Clear';
+import SearchIcon from '@mui/icons-material/Search';
+import {
+  Autocomplete, CircularProgress, IconButton, Paper, TextField,
+} from '@mui/material';
+import booleanWithin from '@turf/boolean-within';
+import { multiPolygon, point, polygon } from '@turf/helpers';
+import { cellToLatLng, getResolution } from 'h3-js';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  setFilteredDatasets, setLastZoom, setLocation, setPendingLocationCheck,
+} from 'store/locationSlice';
+import { setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import { RootState } from 'store/store';
+import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
+import isEqual from 'lodash.isequal';
+import uniqWith from 'lodash.uniqwith';
+import isEqualWith from 'lodash.isequalwith';
+import moveViewportToBbox from 'utils/moveViewportToBbox';
+import { selectAccessibilities, selectSourceOrgFilters } from 'store/selectedFiltersSlice';
+import { parse } from 'date-fns';
+
+function SearchButton({ isLoading }: { isLoading: boolean }) {
+  return (
+    <div className="flex justify-center items-center w-[2em] mr-[-8px]">
+      {
+      isLoading ? <CircularProgress size="1em" /> : (
+        <IconButton aria-label="search" type="submit">
+          <SearchIcon />
+        </IconButton>
+      )
+    }
+    </div>
+  );
+}
+
+function ClearButton() {
+  return (
+    <div className="flex justify-center items-center w-[2em] mr-[-8px]">
+      <IconButton arial-label="clear" type="reset">
+        <ClearIcon />
+      </IconButton>
+    </div>
+  );
+}
+
+function Search({ className }: { className?: string }) {
+  const [query, setQuery] = useState('');
+  const [options, setOptions] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const dispatch = useDispatch();
+  const { h3Index: selectedH3Index }: { h3Index: string } = useSelector((state: RootState) => state.selected);
+  const viewState = useSelector((state: RootState) => state.carto.viewState);
+  const { location, lastZoom } = useSelector((state: RootState) => state.location);
+  const sourceOrgs = useSelector(selectSourceOrgFilters);
+  const accessibilities = useSelector(selectAccessibilities);
+
+  const getDatasets = async ({ location, zoom }: { location: any, zoom: number }) => {
+    const [_, resolution] = getSteppedZoomResolutionPair(zoom);
+    const datasetsResp = await fetch(`${import.meta.env.VITE_API_URL}/datasets_by_location/`, {
+      method: 'post',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        location: JSON.stringify(location.geojson),
+        resolution,
+        source_org: sourceOrgs,
+        accessibility: accessibilities,
+      }),
+    });
+    const datasetsResults = await datasetsResp.json();
+    if (datasetsResults) {
+      dispatch(setFilteredDatasets(datasetsResults));
+    }
+
+    dispatch(setPendingLocationCheck(true));
+    if (selectedH3Index) {
+      // deselect current tile if it's not among the tiles rendered inside the location feature
+      const locationFeature = (location.geojson.type === 'Polygon' ? polygon : multiPolygon)(location.geojson.coordinates);
+      const selectedTilePoint = point(cellToLatLng(selectedH3Index).reverse());
+      if (getResolution(selectedH3Index) !== resolution || !booleanWithin(selectedTilePoint, locationFeature)) {
+        dispatch(setSelectedH3Index(null));
+      }
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    const encodedQuery = new URLSearchParams(query).toString();
+    const parseResp = await fetch(`${import.meta.env.VITE_API_URL}/search/parse?query=${encodedQuery}`);
+    const results = await parseResp.json();
+    console.log(results);
+    // const resp = await fetch(
+    //   `https://nominatim.openstreetmap.org/search?q=${encodedQuery}&format=json&polygon_geojson=1`,
+    // );
+    // const results = await resp.json();
+    // if (results == null || results.length === 0) {
+    //   setIsError(true);
+    // } else {
+    //   const dedupedResults = uniqWith(results, (result: any, other: any) => isEqualWith(result, other, (result: any, other: any) => isEqual(result.geojson.coordinates, other.geojson.coordinates)));
+    //   setOptions(dedupedResults);
+    // }
+    setIsLoading(false);
+  };
+
+  const selectLocation = (event: React.ChangeEvent<HTMLInputElement>, location: any | null) => {
+    setQuery(location.display_name || location.option.name);
+
+    const [minLat, maxLat, minLon, maxLon] = location.boundingbox.map(parseFloat);
+    const bbox = {
+      minLat, maxLat, minLon, maxLon,
+    };
+    dispatch(setLocation(location));
+    const { zoom } = moveViewportToBbox(bbox, viewState, dispatch);
+    dispatch(setLastZoom(zoom));
+    if (['Polygon', 'MultiPolygon'].includes(location.geojson.type)) {
+      getDatasets({ location, zoom });
+    }
+  };
+
+  const clearLocation = () => {
+    setQuery('');
+    setIsError(false);
+    setOptions([]);
+    dispatch(setLocation(null));
+    dispatch(setLastZoom(null));
+    dispatch(setFilteredDatasets(null));
+  };
+
+  useEffect(() => {
+    if (location && lastZoom) {
+      getDatasets({ location, zoom: lastZoom });
+    }
+  }, [sourceOrgs, accessibilities]);
+
+  // use Autocomplete as the base component since it conveniently
+  // combines free text search and dropdown functionalities
+
+  return (
+    <form className="w-full" onSubmit={handleSubmit} onReset={clearLocation}>
+      <Autocomplete
+        id="location-search"
+        options={options}
+        // disable filtering based on substring matching; simply use all of nominatim's results
+        filterOptions={(options, state) => options}
+        getOptionLabel={(option) => option.display_name || option.name}
+        isOptionEqualToValue={(option, value) => option.place_id === value.place_id}
+        inputValue={query}
+        onChange={selectLocation}
+        renderInput={(params) => (
+          <TextField
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...params}
+            error={isError}
+            helperText={isError && 'No results.'}
+            label="Search"
+            variant="outlined"
+            value={query}
+            onChange={
+              (event: React.ChangeEvent<HTMLInputElement>) => {
+                setIsError(false);
+                setQuery(event.target.value);
+              }
+            }
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  <SearchButton isLoading={isLoading} />
+                  <ClearButton />
+                </>
+              ),
+            }}
+          />
+        )}
+        // disable popup and clear to reclaim their reserved space
+        // custom behavior is used in their place
+        forcePopupIcon={false}
+        disableClearable
+        // prevent the 'No options' notice from showing
+        // while the user is still inputting their query
+        open={options.length > 0}
+        openOnFocus={false}
+        onClose={(event: React.SyntheticEvent, reason: string) => { setOptions([]); }}
+      />
+    </form>
+  );
+}
+
+export default Search;

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -183,6 +183,13 @@ function Search({ className }: { className?: string }) {
     dispatch(setDatasetIds(datasetIds));
     if (location.skip) {
       dispatch(setDatasets(datasets));
+      if (datasets[0]?.bbox) {
+        const [w, s, e, n] = datasets[0].bbox;
+        const bbox = {
+          minLat: s, maxLat: n, minLon: w, maxLon: e,
+        };
+        moveViewportToBbox(bbox, viewState, dispatch);
+      }
       // fly map to first dataset's bbox
       return;
     }

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -152,6 +152,7 @@ function Search({ className }: { className?: string }) {
         keywordPayload_.max_year = yearEntity.text;
       }
 
+      let labelWhitelist = ['statistical indicator'] as string[];
       setKeywordPayload(keywordPayload_);
       if (regionEntity || countryEntity || entities.length === 0) {
         let locationQ;
@@ -177,11 +178,13 @@ function Search({ className }: { className?: string }) {
           );
           setOptions([{ display_name: 'Skip geography filtering', name: 'Skip geography filtering', skip: true }, ...dedupedResults]);
           return;
+        } else {
+          labelWhitelist = [...labelWhitelist, 'region', 'country'];
         }
       }
 
       setIsLoading(true);
-      const entitiesToStrip = entities.filter((e) => !['year'].includes(e.label));
+      const entitiesToStrip = entities.filter((e) => !labelWhitelist.includes(e.label));
       keywordPayload_.query = stripEntities(query, entitiesToStrip);
       try {
         const { data } = await axios.get(
@@ -242,7 +245,6 @@ function Search({ className }: { className?: string }) {
     const hasNoEntities = Array.isArray(entities) && entities.length === 0;
     let params = keywordPayload;
 
-    console.info('Location skipped?', location.skip);
     let keywordQ;
     if (hasNoEntities) {
       console.info('No entities');

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -22,7 +22,12 @@ import {
   setDatasetIds,
   setH3IndexedDatasets,
 } from 'store/selectedFiltersSlice';
-import { resetDatasets, setDatasets, setH3Index as setSelectedH3Index } from 'store/selectedSlice';
+import {
+  resetDatasets,
+  setDatasets,
+  setSelectedDataset,
+  setH3Index as setSelectedH3Index,
+} from 'store/selectedSlice';
 import { RootState } from 'store/store';
 import getSteppedZoomResolutionPair from 'utils/getSteppedZoomResolutionPair';
 import moveViewportToBbox from 'utils/moveViewportToBbox';
@@ -106,7 +111,6 @@ function Search({ className }: { className?: string }) {
     setIsLoading(true);
     const encodedQuery = new URLSearchParams(query).toString();
 
-    // add source org and accessibility filters
     try {
       const keywordPayload_: any = {
         query: encodedQuery,
@@ -160,6 +164,8 @@ function Search({ className }: { className?: string }) {
       }
 
       const { hits: datasets } = await getDatasetsByKeyword(keywordPayload_);
+      dispatch(setSelectedDataset(null));
+      dispatch(setSelectedH3Index(null));
       dispatch(setDatasetIds(datasets.map((d: Dataset) => d.id)));
       dispatch(setDatasets(datasets));
     } catch (err) {
@@ -180,6 +186,8 @@ function Search({ className }: { className?: string }) {
   const selectLocation = async (event: React.ChangeEvent<HTMLInputElement>, location: any | null) => {
     const { hits: datasets } = await getDatasetsByKeyword();
     const datasetIds = datasets.map((d: Dataset) => d.id);
+    dispatch(setSelectedDataset(null));
+    dispatch(setSelectedH3Index(null));
     dispatch(setDatasetIds(datasetIds));
     if (location.skip) {
       dispatch(setDatasets(datasets));

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -237,9 +237,13 @@ function Search({ className }: { className?: string }) {
       if (hasNoEntities) {
         keywordQ = query;
       } else {
-        keywordQ = [regionEntity?.text, countryEntity?.text].filter((e: string) => e).join(',');
+        // eslint-disable-next-line no-lonely-if
         if (hasStatIndicator) {
-          keywordQ += `,${statIndicatorEntity.text}`;
+          keywordQ = [regionEntity?.text, countryEntity?.text, statIndicatorEntity?.text].filter((e: string) => e).join(',');
+        } else {
+          // if no explicit stat indicator is detected,
+          // repass the raw query
+          keywordQ = query;
         }
       }
       params = { ...keywordPayload, query: keywordQ };

--- a/ui/src/components/search/Search.tsx
+++ b/ui/src/components/search/Search.tsx
@@ -14,6 +14,9 @@ import uniqWith from 'lodash.uniqwith';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  resetByKey as resetPreviewByKey,
+} from 'store/previewSlice';
+import {
   resetByKey as resetSearchByKey,
   setLastZoom,
   setLocation,
@@ -140,7 +143,6 @@ function Search({ className }: { className?: string }) {
 
       setKeywordPayload(keywordPayload_);
       if (regionEntity || countryEntity || entities.length === 0) {
-        // console.log(regionEntity, countryEntity, query);
         const locationQ = regionEntity?.text || countryEntity?.text || query;
         const { data: nominatimResults } = await axios.get(
           'https://nominatim.openstreetmap.org/search',
@@ -190,6 +192,7 @@ function Search({ className }: { className?: string }) {
     dispatch(setDatasetIds(datasetIds));
     if (location.skip) {
       dispatch(setDatasets(datasets));
+      // we fly the map to the first ranked dataset
       if (datasets[0]?.bbox) {
         const [w, s, e, n] = datasets[0].bbox;
         const bbox = {
@@ -197,7 +200,6 @@ function Search({ className }: { className?: string }) {
         };
         moveViewportToBbox(bbox, viewState, dispatch);
       }
-      // fly map to first dataset's bbox
       return;
     }
     const [minLat, maxLat, minLon, maxLon] = location.boundingbox.map(parseFloat);
@@ -216,6 +218,7 @@ function Search({ className }: { className?: string }) {
     setQuery('');
     setIsError(false);
     setOptions([]);
+    dispatch(resetPreviewByKey('fileUrl', 'isLoadingPreview', 'errorMessage'));
     dispatch(resetSearchByKey('location', 'lastZoom'));
     dispatch(resetSelectedByKey('datasets'));
     dispatch(resetSelectedFiltersByKey('datasetIds', 'h3IndexedDatasets'));

--- a/ui/src/components/views/main/MapContainer.tsx
+++ b/ui/src/components/views/main/MapContainer.tsx
@@ -68,7 +68,7 @@ export default function MapContainer() {
     <GridMapWrapper item isGmaps={isGmaps}>
       <Map layers={layers} />
       {!hidden && <StyledZoomControl showCurrentZoom className="zoomControl" />}
-      <LocationSearch className="absolute top-2.5 left-2.5 p-2 w-72" />
+      {/* <LocationSearch className="absolute top-2.5 left-2.5 p-2 w-72" /> */}
       <PreviewErrorSnackbar />
     </GridMapWrapper>
   );

--- a/ui/src/components/views/main/MapContainer.tsx
+++ b/ui/src/components/views/main/MapContainer.tsx
@@ -68,7 +68,6 @@ export default function MapContainer() {
     <GridMapWrapper item isGmaps={isGmaps}>
       <Map layers={layers} />
       {!hidden && <StyledZoomControl showCurrentZoom className="zoomControl" />}
-      {/* <LocationSearch className="absolute top-2.5 left-2.5 p-2 w-72" /> */}
       <PreviewErrorSnackbar />
     </GridMapWrapper>
   );

--- a/ui/src/store/previewSlice.ts
+++ b/ui/src/store/previewSlice.ts
@@ -1,13 +1,15 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
 
+const initialState: any = {
+  fileUrl: null,
+  isLoadingPreview: false,
+  errorMessage: null,
+};
+
 const slice = createSlice({
   name: 'preview',
-  initialState: {
-    fileUrl: null,
-    isLoadingPreview: false,
-    errorMessage: null,
-  },
+  initialState,
   reducers: {
     setFileUrl: (state, action) => {
       state.fileUrl = action.payload;
@@ -17,6 +19,11 @@ const slice = createSlice({
     },
     setErrorMessage: (state, action) => {
       state.errorMessage = action.payload;
+    },
+    resetByKey: (state, action) => {
+      action.payload.forEach((key: string) => {
+        state[key] = initialState[key];
+      });
     },
   },
 });
@@ -33,5 +40,9 @@ export const setIsLoadingPreview = (payload: boolean) => ({
 });
 export const setErrorMessage = (payload: string) => ({
   type: 'preview/setErrorMessage',
+  payload,
+});
+export const resetByKey = (...payload: string[]) => ({
+  type: 'preview/resetByKey',
   payload,
 });

--- a/ui/src/store/searchSlice.ts
+++ b/ui/src/store/searchSlice.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
-import { Dataset } from 'components/common/types';
 
 const slice = createSlice({
   name: 'search',
@@ -8,9 +7,7 @@ const slice = createSlice({
     query: null,
     location: null,
     lastZoom: null,
-    filteredDatasets: null,
     pendingLocationCheck: false,
-    datasetIds: [],
   },
   reducers: {
     setQuery: (state, action) => {
@@ -22,14 +19,8 @@ const slice = createSlice({
     setLastZoom: (state, action) => {
       state.lastZoom = action.payload;
     },
-    setFilteredDatasets: (state, action) => {
-      state.filteredDatasets = action.payload;
-    },
     setPendingLocationCheck: (state, action) => {
       state.pendingLocationCheck = action.payload;
-    },
-    setDatasetIds: (state, action) => {
-      state.datasetIds = action.payload;
     },
   },
 });
@@ -48,15 +39,7 @@ export const setLastZoom = (payload: any) => ({
   type: 'search/setLastZoom',
   payload,
 });
-export const setFilteredDatasets = (payload: Dataset[]) => ({
-  type: 'search/setFilteredDatasets',
-  payload,
-});
 export const setPendingLocationCheck = (payload: boolean) => ({
   type: 'search/setPendingLocationCheck',
-  payload,
-});
-export const setDatasetIds = (payload: number[]) => ({
-  type: 'search/setDatasetIds',
   payload,
 });

--- a/ui/src/store/searchSlice.ts
+++ b/ui/src/store/searchSlice.ts
@@ -1,18 +1,20 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
 
+const initialState: any = {
+  // query: null,
+  location: null,
+  lastZoom: null,
+  pendingLocationCheck: false,
+};
+
 const slice = createSlice({
   name: 'search',
-  initialState: {
-    query: null,
-    location: null,
-    lastZoom: null,
-    pendingLocationCheck: false,
-  },
+  initialState,
   reducers: {
-    setQuery: (state, action) => {
-      state.query = action.payload;
-    },
+    // setQuery: (state, action) => {
+    //   state.query = action.payload;
+    // },
     setLocation: (state, action) => {
       state.location = action.payload;
     },
@@ -22,15 +24,20 @@ const slice = createSlice({
     setPendingLocationCheck: (state, action) => {
       state.pendingLocationCheck = action.payload;
     },
+    resetByKey: (state, action) => {
+      action.payload.forEach((key: string) => {
+        state[key] = initialState[key];
+      });
+    },
   },
 });
 
 export default slice.reducer;
 
-export const setQuery = (payload: string | null) => ({
-  type: 'search/setQuery',
-  payload,
-});
+// export const setQuery = (payload: string | null) => ({
+//   type: 'search/setQuery',
+//   payload,
+// });
 export const setLocation = (payload: any) => ({
   type: 'search/setLocation',
   payload,
@@ -41,5 +48,9 @@ export const setLastZoom = (payload: any) => ({
 });
 export const setPendingLocationCheck = (payload: boolean) => ({
   type: 'search/setPendingLocationCheck',
+  payload,
+});
+export const resetByKey = (...payload: string[]) => ({
+  type: 'search/resetByKey',
   payload,
 });

--- a/ui/src/store/searchSlice.ts
+++ b/ui/src/store/searchSlice.ts
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { Dataset } from 'components/common/types';
 
 const slice = createSlice({
-  name: 'location',
+  name: 'search',
   initialState: {
     query: null,
     location: null,

--- a/ui/src/store/searchSlice.ts
+++ b/ui/src/store/searchSlice.ts
@@ -10,6 +10,7 @@ const slice = createSlice({
     lastZoom: null,
     filteredDatasets: null,
     pendingLocationCheck: false,
+    datasetIds: [],
   },
   reducers: {
     setQuery: (state, action) => {
@@ -27,28 +28,35 @@ const slice = createSlice({
     setPendingLocationCheck: (state, action) => {
       state.pendingLocationCheck = action.payload;
     },
+    setDatasetIds: (state, action) => {
+      state.datasetIds = action.payload;
+    },
   },
 });
 
 export default slice.reducer;
 
 export const setQuery = (payload: string | null) => ({
-  type: 'location/setQuery',
+  type: 'search/setQuery',
   payload,
 });
 export const setLocation = (payload: any) => ({
-  type: 'location/setLocation',
+  type: 'search/setLocation',
   payload,
 });
 export const setLastZoom = (payload: any) => ({
-  type: 'location/setLastZoom',
+  type: 'search/setLastZoom',
   payload,
 });
 export const setFilteredDatasets = (payload: Dataset[]) => ({
-  type: 'location/setFilteredDatasets',
+  type: 'search/setFilteredDatasets',
   payload,
 });
 export const setPendingLocationCheck = (payload: boolean) => ({
-  type: 'location/setPendingLocationCheck',
+  type: 'search/setPendingLocationCheck',
+  payload,
+});
+export const setDatasetIds = (payload: number[]) => ({
+  type: 'search/setDatasetIds',
   payload,
 });

--- a/ui/src/store/selectedFiltersSlice.ts
+++ b/ui/src/store/selectedFiltersSlice.ts
@@ -2,15 +2,17 @@ import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { Dataset } from 'components/common/types';
 import { RootState } from './store';
 
+const initialState: any = {
+  sourceOrgs: {},
+  accessibilities: {},
+  // TODO: rename to candidate dataset ids
+  datasetIds: [],
+  h3IndexedDatasets: [],
+};
+
 const slice = createSlice({
   name: 'selectedFilters',
-  initialState: {
-    sourceOrgs: {},
-    accessibilities: {},
-    datasetIds: [],
-    h3IndexedDatasets: [],
-  },
-
+  initialState,
   reducers: {
     setSourceOrgs: (state, action) => {
       state.sourceOrgs = action.payload;
@@ -39,6 +41,11 @@ const slice = createSlice({
     // move this elsewhere
     setH3IndexedDatasets: (state, action) => {
       state.h3IndexedDatasets = action.payload;
+    },
+    resetByKey: (state, action) => {
+      action.payload.forEach((key: string) => {
+        state[key] = initialState[key];
+      });
     },
   },
 });
@@ -98,5 +105,10 @@ export const setDatasetIds = (payload: number[]) => ({
 
 export const setH3IndexedDatasets = (payload: Dataset[]) => ({
   type: 'selectedFilters/setH3IndexedDatasets',
+  payload,
+});
+
+export const resetByKey = (...payload: string[]) => ({
+  type: 'selectedFilters/resetByKey',
   payload,
 });

--- a/ui/src/store/selectedFiltersSlice.ts
+++ b/ui/src/store/selectedFiltersSlice.ts
@@ -1,4 +1,5 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit';
+import { Dataset } from 'components/common/types';
 import { RootState } from './store';
 
 const slice = createSlice({
@@ -6,6 +7,8 @@ const slice = createSlice({
   initialState: {
     sourceOrgs: {},
     accessibilities: {},
+    datasetIds: [],
+    h3IndexedDatasets: [],
   },
 
   reducers: {
@@ -26,6 +29,16 @@ const slice = createSlice({
         ...state.accessibilities,
         ...action.payload,
       };
+    },
+    // not to be confused with the selected.datasets
+    // this are keyword-search-derived ids and needs
+    // to be a separate state for filtering purposes
+    setDatasetIds: (state, action) => {
+      state.datasetIds = action.payload;
+    },
+    // move this elsewhere
+    setH3IndexedDatasets: (state, action) => {
+      state.h3IndexedDatasets = action.payload;
     },
   },
 });
@@ -77,3 +90,13 @@ export const selectAccessibilities = createSelector(
     return selectedAccessibilities;
   },
 );
+
+export const setDatasetIds = (payload: number[]) => ({
+  type: 'selectedFilters/setDatasetIds',
+  payload,
+});
+
+export const setH3IndexedDatasets = (payload: Dataset[]) => ({
+  type: 'selectedFilters/setH3IndexedDatasets',
+  payload,
+});

--- a/ui/src/store/selectedSlice.ts
+++ b/ui/src/store/selectedSlice.ts
@@ -1,16 +1,17 @@
 /* eslint-disable no-param-reassign */
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { Dataset } from 'components/common/types';
-import { RootState } from './store';
+
+const initialState: any = {
+  h3Index: null,
+  datasets: [],
+  datasetCount: null,
+  selectedDataset: null,
+};
 
 const slice = createSlice({
   name: 'selected',
-  initialState: {
-    h3Index: null,
-    datasets: [],
-    datasetCount: null,
-    selectedDataset: null,
-  },
+  initialState,
   reducers: {
     setH3Index: (state, action) => {
       state.h3Index = action.payload;
@@ -25,8 +26,10 @@ const slice = createSlice({
     setSelectedDataset: (state, action) => {
       state.selectedDataset = action.payload;
     },
-    resetDatasets: (state, action) => {
-      state.datasets = [];
+    resetByKey: (state, action) => {
+      action.payload.forEach((key: string) => {
+        state[key] = initialState[key];
+      });
     },
   },
 });
@@ -49,6 +52,7 @@ export const setSelectedDataset = (payload: number) => ({
   type: 'selected/setSelectedDataset',
   payload,
 });
-export const resetDatasets = () => ({
-  type: 'selected/resetDatasets',
+export const resetByKey = (...payload: string[]) => ({
+  type: 'selected/resetByKey',
+  payload,
 });

--- a/ui/src/store/selectedSlice.ts
+++ b/ui/src/store/selectedSlice.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-param-reassign */
-import { createSlice } from '@reduxjs/toolkit';
+import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { Dataset } from 'components/common/types';
+import { RootState } from './store';
 
 const slice = createSlice({
   name: 'selected',
   initialState: {
     h3Index: null,
-    datasets: null,
+    datasets: [],
     datasetCount: null,
     selectedDataset: null,
   },
@@ -14,6 +15,7 @@ const slice = createSlice({
     setH3Index: (state, action) => {
       state.h3Index = action.payload;
     },
+    // should be on a different slice
     setDatasets: (state, action) => {
       state.datasets = action.payload;
     },
@@ -22,6 +24,9 @@ const slice = createSlice({
     },
     setSelectedDataset: (state, action) => {
       state.selectedDataset = action.payload;
+    },
+    resetDatasets: (state, action) => {
+      state.datasets = [];
     },
   },
 });
@@ -43,4 +48,7 @@ export const setDatasetCount = (payload: number) => ({
 export const setSelectedDataset = (payload: number) => ({
   type: 'selected/setSelectedDataset',
   payload,
+});
+export const resetDatasets = () => ({
+  type: 'selected/resetDatasets',
 });

--- a/ui/src/store/store.ts
+++ b/ui/src/store/store.ts
@@ -9,7 +9,7 @@ import {
   Store,
 } from 'redux';
 import appSlice from './appSlice';
-import locationSlice from './locationSlice';
+import searchSlice from './searchSlice';
 import selectedSlice from './selectedSlice';
 import previewSlice from './previewSlice';
 import selectedFiltersSlice from './selectedFiltersSlice';
@@ -22,7 +22,7 @@ interface AppStore extends Store {
 // Define the Reducers that will always be present in the application
 const staticReducers = {
   app: appSlice,
-  location: locationSlice,
+  search: searchSlice,
   selected: selectedSlice,
   preview: previewSlice,
   selectedFilters: selectedFiltersSlice,

--- a/ui/src/utils/api.ts
+++ b/ui/src/utils/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const apiFetch = async (url: string, options = {}) => {
+  const resp = await axios(`${import.meta.env.VITE_API_URL}/${url}`, options);
+  return resp;
+};
+
+export default apiFetch;

--- a/ui/src/utils/moveViewportToBbox.ts
+++ b/ui/src/utils/moveViewportToBbox.ts
@@ -5,14 +5,16 @@ import bboxToViewStateParams from './bboxToViewStateParams';
 import getSteppedZoomResolutionPair from './getSteppedZoomResolutionPair';
 
 // @ts-ignore
-const moveViewportToBbox = (bbox: BoundingBox, viewState: ViewState, dispatch: any): ViewState => {
+const moveViewportToBbox = (bbox: BoundingBox, viewState: ViewState, dispatch: any, dryRun: boolean = false): ViewState => {
   const { width, height } = viewState;
   const viewStateParams = bboxToViewStateParams({ bbox, width, height });
   // TODO: add minimum zoom level of 2 as a config
   const zoom = Math.max(viewStateParams.zoom, 2);
-  dispatch(setViewState({ ...viewState, ...viewStateParams, zoom }));
-  dispatch(setSteppedZoom(getSteppedZoomResolutionPair(zoom)[0]));
-  return viewStateParams;
+  if (!dryRun) {
+    dispatch(setViewState({ ...viewState, ...viewStateParams, zoom }));
+    dispatch(setSteppedZoom(getSteppedZoomResolutionPair(zoom)[0]));
+  }
+  return { ...viewStateParams, zoom };
 };
 
 export default moveViewportToBbox;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,5 +1,5 @@
-import react from '@vitejs/plugin-react';
 import path from 'path';
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import eslintPlugin from 'vite-plugin-eslint';
@@ -33,7 +33,7 @@ export default defineConfig({
     }),
     viteTsconfigPaths(),
     svgrPlugin(),
-    pluginRewriteAll()
+    pluginRewriteAll(),
   ],
   build: {
     outDir: 'build',
@@ -66,6 +66,6 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/cors-anywhere/, ''),
         secure: false,
       },
-    }
-  }
+    },
+  },
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5476,6 +5476,15 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
+axios@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.1.tgz#39c378a6e3b06ca679f29138151e45b2b32da62a"
@@ -8725,6 +8734,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -8768,6 +8782,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -14040,7 +14063,7 @@ proxy-agent@^5.0.0:
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^5.0.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==


### PR DESCRIPTION
## Search heuristics
- Parse search query (`/search/parse`) which returns entities. If year entity is detected, set it as a filter along with the source organization and accessibility filters.
- Query nominatim: use location entity (region/country ) if found, otherwise use the raw query.
  - If there are location results, present these along with the option to skip choosing a location. Go to `Select location`
  - If there are no results, go to `No nominatim results`

### No nominatim results

- Exempt `statistical indicator`, `region`, and `country` entities from being "stripped". Strip the remaining `year` entity and stop words (`/search/strip_stop_words`) from the raw query and use it as the keyword argument
- Do a keyword search (`/search/keyword`) of the datasets
- Display the resulting datasets

### Select location
- Prep the keyword argument
  - If there were no entities parsed, set the raw query as the keyword argument
  - If there were entities parsed, strip them and the stop words from raw query. Exempt `statistical indicator` and, if the user skipped location filtering, the `region` and `country` entities as well from being stripped. The `year` entity gets stripped regardless
- If the keyword argument is still non-empty after stripping, do a keyword search and tag the resulting datasets as _candidate_ datasets
    - If there were no resulting datasets, then the search as a whole did not yield any datasets. END.
 
#### Skip
- With the location filter being skipped, display the candidate datasets as the overall results.
- Reset the map view so the user can see the resulting datasets. END.

#### Filter by location
- Filter the candidate datasets to those that are within the selected location `/datasets_by_location`
- Display the overall resulting datasets and fly the map to the selected location. END.

- [ ] Document manual test cases (we should really write automated tests when we have time especially for a complex feature/component like the search's heuristics)

# Screenshot
<img width="1355" alt="image" src="https://github.com/avsolatorio/worldex/assets/8906131/16df5411-e38d-4b1c-9ea2-e7ba3de89c6b">
