### PR TITLE
docs: Revise provisioning local/bare metal environments; document strategy for storing, querying datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,19 @@ If you are on an ARM-based device (e.g. M1/M2 MacBooks), comment out the followi
 ```
 dockerfile: arm64.Dockerfile
 ```
-This will build a more appropriate image for your host machine. Otherwise, the PostGIS service will still run but performance/queries will be much slower on your local environment.
+The PostGIS build will be more performant on your local machine this way.
 
 ## `docker compose up`
 
 to run the development environment on local. Simply interrupt to stop the cluster or `docker compose down` if you ran it in detached mode.
 
-Note however that this doesn't start a dev server for the vite app however. You'll have to run `yarn` to install the dependencies and
+Note that this doesn't start a dev server for the vite app. You'll have to run `yarn` to install the dependencies and
 
 ### `yarn start`
 
-to run the dev server. Our current reason for excluding this from the compose cluster is that while we can bind-mount the source code for hot reloads, we cannot do the same for `node_modules` in case the dependencies were installed on a different architecture (e.g. mac host, linux container).
+to run the dev server. We exclude the vite app from the compose cluster since we cannot bind mount `node_modules` if the dependencies were installed on a different architecture (e.g. mac host, linux container).
+
+You may need `--force` if you encounter issues with the lockfile.
 
 Outside of development context that requires hot reloads, you can run the following.
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ The project consists of a web application that allows for users to explore the a
 
 APIs are implemented to allow users to interact with the indexed data.
 
-# Local Development
+## Local Development
 
-First off, install [`just`](https://github.com/casey/just#installation). It is similar to `make` in that it's just a convenient wrapper around some cli commands to setup the local environment.
+First, install [`just`](https://github.com/casey/just#installation). It is similar to `make` in that it's just a convenient wrapper around lengthier cli commands to setup the local environment.
 
-## `cd secrets && poetry install`
+### `cd secrets && poetry install`
 to setup the simple password generator.
 
-## `just prep-aws-env`
-to setup aws environment variables (including credentials) for dataset seeding later. This will create a `./secrets/aws.env` file. However, without secret manager you'll have to fill the aws key id and secret manually.
+### `just prep-aws-env`
+to setup aws environment variables (credentials, etc.) to access parquet files for dataset seeding later. This will create a `./secrets/aws.env` file. At the time of writing however, you'll have to fill the aws key id and secret manually.
 
-Ask the repo maintainers if you're part of the same team.
+Ask the repo maintainers if you're part of the same team. Eventually, these parquet files should be made publicly accessible.
 
 <span style="color:red">If you're on a Mac,</span> you may have to run the following first to enable `envsubst`
 
@@ -25,53 +25,62 @@ brew install gettext
 brew link --force gettext
 ```
 
-## `just generate-es-password`
+### `just generate-es-password`
 to generate a password to the `elastic` user of the `es` elasticsearch service
 
-## `just refresh-db-password`
+### `just refresh-db-password`
 to generate a postgres password and the environment files to be used by the `api`, `db`, and `pgweb` services as per the docker compose spec.
 
 If you've previously generated a postgres password with this command and just want to regenerate the environment files, run `create-envs`
 
-## PostGIS on ARM-based devices
-If you are on an ARM-based device (e.g. M1/M2 MacBooks), comment out the following line under the `db` service on `docker-compose.yaml`, comment out the following line
+### PostGIS on ARM-based devices
+If you are on an ARM-based device (e.g. M1/M2 MacBooks), comment out the following line under the `db` service on `docker-compose.yaml`
 ```
 dockerfile: arm64.Dockerfile
 ```
-The PostGIS build will be more performant on your local machine this way.
+This PostGIS build will be more performant on your local machine.
 
-## `docker compose up`
+### `docker compose up -d`
 
-to run the development environment on local. Simply interrupt to stop the cluster or `docker compose down` if you ran it in detached mode.
+to run the development environment on local. `docker compose down` to stop it.
 
-Note that this doesn't start a dev server for the vite app. You'll have to run `yarn` to install the dependencies and
+Note that the cluster doesn't include the vite app by default. You'll have to run `yarn` to install the dependencies and
 
 ### `yarn start`
 
-to run the dev server. We exclude the vite app from the compose cluster since we cannot bind mount `node_modules` if the dependencies were installed on a different architecture (e.g. mac host, linux container).
+to run the dev server. We exclude the vite app since `node_modules` cannot be bind-mount if the dependencies were installed on a different architecture (e.g. mac host, linux container).
 
-You may need `--force` if you encounter issues with the lockfile.
+You may need to `--force` if you encounter issues with the lockfile.
 
-Outside of development context that requires hot reloads, you can run the following.
+If you're outside of development context that requires hot reloads, you can run the following to run/test actual builds of the vite app.
 
 ### `docker compose --profile preview up -d`
 
-will run `vite preview` on a built version of the app while
+will run `vite preview` to preview the production build (not actually intended as a production server)
 
 ### `docker compose --profile web up -d`
 
-will run an nginx reverse proxy serving the built version of the vite app
+will run an nginx reverse proxy serving the vite app build.
 
 ## API service
-The api (and database) service are not quite ready yet at this point. See the API [readme](api/README.md) to finish setting them up.
+See the API [readme](api/README.md) to finish setting the api (along with the database) service up.
+
+## Elasticsearch
+We use this service to search against dataset metadata. After populating your database with the pre-indexed datasets, from the `/api` directory run
+
+```
+just run-script es_index_dataset
+```
+
+You can use https://elasticvue.com/ as a gui to the elasticsearch service/indices - the browser extension is sufficient. You will have to provide the uri http://localhost:9200 and the generated credentials to connect to the cluster.
 
 ## Pre-commit
 
-is used to minimize nitpicking stemming from formatting and other minor issues during code review.
+is used to minimize nitpicks such as formatting during code review.
 
 ### `pip install pre-commit`
 
-to install pre-commit. Alternatively, see https://pre-commit.com/ for installation instructions.
+to install pre-commit. Or see https://pre-commit.com/ for installation instructions.
 
 ### `pre-commit install`
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,10 +1,8 @@
 This FastAPI app runs on Python 3.10.x
 
-All services are currently running on a docker compose cluster which has some implications with the development experience on the api backend.
-
 ###  `poetry install --with handlers`
 
-to create a poetry-managed virtualenv on your host machine. This is recommended so you don't have to `docker exec` a shell inside the fastapi container every time you want to issue, say, `alembic` commands.
+to create a poetry-managed virtualenv on your host machine. This is recommended so you don't have to `docker exec` a shell inside the fastapi container every time you want to issue  `alembic` commands or run scripts.
 
 ### Install [direnv](https://direnv.net/docs/installation.html)
 
@@ -13,53 +11,77 @@ first to load the necessary environment variables prior to running the commands 
 #### `direnv allow`
 inside the `api` directory aftewrwards to load the variables from `.envrc`
 
-## Database migrations
-
-Right now, the postgis database is being populated with a few datasets via alembic migration. We are planning to decouple this eventually as standalone scripts, but for now you will need the [Nigeria schools and population](https://github.com/avsolatorio/worldex/files/12481827/nigeria-schools-and-population-density.zip) and Critical Habitat (download link to follow or ask any of the repo maintainers) datasets.
-
-You will need to download them into the `/tmp/datasets/` directory of your host machine. Additionally, you will have to unzip the Nigeria datasets. You can leave the Critical Habitat zipfile as is.
-
-### `just migrate-db`
-from `/api` to apply the database migrations. If you need to troubleshoot or would like a more fine-grained control, you can run
-
-#### `docker compose exec -it api /bin/bash`
-to run a shell instance on the api service. Afterwards, you can issue your commands such as
-
-#### `alembic upgrade head`
-which is exactly what `just migrate-db` does.
-
 ## Populating the database
 
-You can populate the database with a few datasets stored in an aws bucket. From the `api` directory run
+### The quick way
+
+A pgdump of a small subset of currently indexed datasets can be downloaded from https://storage.googleapis.com/worldex-dump/worldex.dump <span style="color:red">*</span>
+
+To restore, first make the dump accessible on your db container
 
 ```
-just run-script index_nigeria_pop_density
+docker compose cp worldex.dump db:worldex.dump
 ```
 
-Or alternatively, run the actual command
+From inside the container (either via `docker compose exec -it db /bin/bash` or `docker compose db <command>` directly), run
 
 ```
-poetry run python -m scripts.index_nigeria_pop_density
+pg_restore -Fc -j 8 -f worldex.dump
 ```
 
-See the `api/scripts` directory for the rest you can run.
+You can set the `-j` (`--jobs`) value to the number of cores on your CPU for starters. For more information, see the `number-of-jobs` section on https://www.postgresql.org/docs/current/app-pgrestore.html to know the appropriate value.
 
-# API development
+<span style="color:red">*</span> The database dump was generated with the following command
 
-The api codebase currently hot reloads, so any changes you make should reflect immediately. However, the dependencies are baked in on the docker image. And so...
+```
+pg_dump -U worldex -d worldex -v -Fc -Z 0 --file=worldex.dump
+```
 
-## Using poetry
+### The long way
 
-You will still use the `poetry` command on your host machine to add/remove dependencies, but the docker image (and container) only interacts with the `poetry.lock` and `pyproject.toml`. Which means you'll have to rebuild the image when dependencies are added using
+#### `just migrate-db`
+from `/api` to apply the database migrations. The underlying command is
+
+#### `alembic upgrade head`
+
+which you can run manually from inside the `api` container after `docker compose exec -it api /bin/bash`.
+
+#### Manually indexing the datasets
+
+Many datasets from different source organizations (e.g. WorldPop, HDX, etc.) have been pre-indexed into parquet files and stored in an aws bucket.
+
+To load these into your database, run either
+
+```
+just run-script <script filename>
+```
+
+or
+
+```
+poetry run python -m scripts.<script filename>
+```
+
+At the time of writing, these individual scripts are segregated by source organization and found in `api/scripts`
+
+```
+- index_hdx
+- index_world_pop
+- index_critical_habitat
+```
+
+## API development
+
+The api container currently hot reloads, so changes to the code should reflect immediately. However, the dependencies are setup upon building the docker image. So whenever dependencies are added, you'll have to rebuild the image using
 
 ### `docker compose up api --build`
 
-This is admittedly added toil when compared to ui where the `node_modules` can be bind-mounted and thus `yarn add` commands can be issued from the host.
+You will still use `poetry` from your host environment to add/remove dependencies on `poetry.lock` and `pyproject.toml`.
 
-Unfortunately, the same cannot be done for the poetry-managed `virtualenv`. You will encounter ownership/permission issues if you try to run `poetry` commands from the host for a bind-mounted virtualenv. So we're not doing it unless we find a workaround.
+We do not bind-mount the poetry-managed `virtualenv` as it leads to ownership/permission issues if you try to run `poetry` commands from the host.
 
-
-## Load DB dump
+<details>
+<summary>Load DB dump (archived)</summary>
 
 This is useful for loading an sql dump to a postgresql instance. The dump is located at `/opt/datasets.sql` and can be loaded with the following commands:
 
@@ -76,3 +98,4 @@ psql -d public.datasets -c "CREATE EXTENSION IF NOT EXISTS postgis;" -U postgres
 # Load the dump
 psql -d public.datasets -f /opt/datasets.sql -U postgres
 ```
+</details>

--- a/h3.md
+++ b/h3.md
@@ -1,0 +1,51 @@
+# Storage and querying of H3 indices
+
+Each pre-indexed datasets have a corresponding `h3.parquet` and `metadata.json` file.
+
+The `metadata.json` contains the fields to be inserted into the `datasets` table and an elasticsearch index of the same name.
+
+The `h3.parquet` contains the uncompacted<span style="color:red">*</span> h3 indices at resolution 8 representing the coverage off the geospatial dataset.
+
+<span style="color:red">*</span> See https://h3geo.org/docs/highlights/indexing/ for what uncompacted/compacted means.
+
+## Storage
+
+Ingesting the metadata from file to db/index is a straightforward, more or less 1-1 mapping of fields. The h3 indices, on the other hand, cannot easily be stored as is without the table/dataset size getting inflated.
+
+Instead, we store a compacted version to greatly lessen the number of h3 indices stored especially for datasets covering large "uninterrupted" swathes (think national boundaries).
+
+We also implement some sort of caching where for a given dataset's compacted tile, we store all of its parents up to the lowest/coarsest resolution. For tiles that have the same parent, these parent tiles are deduplicated. These act as "lookup" tiles to determine whether a dataset has a children/coverage under that tile, to avoid expensive `WHERE EXISTS` queries. Later on why this is important.
+
+There's a yet to be deployed optimization that also deduplicates datasets that have exactly the same h3 tile coverage. There is _a lot_ of these in national datasets, which means they are duplicates on a country level (geography dimension) and even on yearly level (time dimension).
+
+## Querying
+
+##### For lower zoom levels (zoomed "out"), we aggregate dataset counts per lower resolution cells.
+
+And vice versa for higher zoom levels (zoomed "in") and higher resolution cells. The mapping between zoom levels and h3 resolutions can be found in [constants/h3.ts](worldex/blob/main/ui/src/constants/h3.ts). It is somewhat arbitrary, and was tuned during development based roughly on visuals and performance.
+
+##### We batch query dataset counts in tiles
+
+One batch corresponds to an OSM/slippy map tile represented in a z/x/y notation. That said, we actually map h3 resolutions to aggregate on with an OSM z-index, and not the actual zoom level of the web map. It can be easy to confuse the two.
+
+This is an important distinction because the map zoom level changes in a continuous manner (and indeed can even have decimal values) whereas the OSM z-index are strictly integers.
+
+Another thing to note is that we map z-indices to h3 resolutions in a stepped manner. We do not need to load a different resolution per change in z-index and thus we can skip some of them.
+
+https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Zoom_levels
+
+##### So what are the actual sql queries like?
+
+Our strategy is as follows:
+
+Per OSM tile, we use an h3 geospatial function to basically fill that rectangle with h3 indices of a given resolution. We refer to them as "fill" tiles from hereon.
+
+Per fill tile, we create an intermediate table (via cte) with another column being an array of all this tile's parents. We then join it with the datasets' h3 tiles if there's an equality between them and any of the tiles' parents or the tile itself.
+
+This captures all dataset tiles that are of the same or lower resolutions of the fill tiles.
+
+**But what about tiles that are of higher resolutions?**
+
+We use a precomputed "lookup" table with "lookup" tiles telling us if a particular dataset has any compacted tile/s that is a child/ren of the lookup tile. Instead of doing expensive `WHERE EXISTS` queries, we can simply join the fill tiles with the lookup tiles to determine if the former contains any dataset tiles of higher resolution.
+
+With h3, aggregating geospatial datasets contained by these tiles do not need to be performed with geospatial functions. They are simply joins based on number equality (h3 tiles are just 64-bit integers represented with a 15-16 character hexadecimal string, e.g. `8928308280fffff`)

--- a/h3.md
+++ b/h3.md
@@ -1,30 +1,30 @@
-# Storage and querying of H3 indices
+# Strategy for storing and querying dataset H3 indices
 
 Each pre-indexed datasets have a corresponding `h3.parquet` and `metadata.json` file.
 
 The `metadata.json` contains the fields to be inserted into the `datasets` table and an elasticsearch index of the same name.
 
-The `h3.parquet` contains the uncompacted<span style="color:red">*</span> h3 indices at resolution 8 representing the coverage off the geospatial dataset.
+The `h3.parquet` contains the uncompacted<span style="color:red">*</span> h3 indices at resolution 8 representing the geographic coverage of the geospatial dataset.
 
 <span style="color:red">*</span> See https://h3geo.org/docs/highlights/indexing/ for what uncompacted/compacted means.
 
 ## Storage
 
-Ingesting the metadata from file to db/index is a straightforward, more or less 1-1 mapping of fields. The h3 indices, on the other hand, cannot easily be stored as is without the table/dataset size getting inflated.
+Ingesting the metadata from file to db/index is a straightforward, more or less 1-1 mapping of fields. The h3 indices, on the other hand, cannot easily be stored as is without the table/dataset size inflating quickly as the number of datasets indexed grows.
 
 Instead, we store a compacted version to greatly lessen the number of h3 indices stored especially for datasets covering large "uninterrupted" swathes (think national boundaries).
 
-We also implement some sort of caching where for a given dataset's compacted tile, we store all of its parents up to the lowest/coarsest resolution. For tiles that have the same parent, these parent tiles are deduplicated. These act as "lookup" tiles to determine whether a dataset has a children/coverage under that tile, to avoid expensive `WHERE EXISTS` queries. Later on why this is important.
+We also implement some sort of caching - for a given dataset's compacted tile, we store all of its parents up to the lowest/coarsest resolution. For tiles that have the same parent, these parent tiles are deduplicated. These act as "lookup" tiles to determine whether a dataset has at least one child under that tile indicating coverage. Later on why this is important.
 
-There's a yet to be deployed optimization that also deduplicates datasets that have exactly the same h3 tile coverage. There is _a lot_ of these in national datasets, which means they are duplicates on a country level (geography dimension) and even on yearly level (time dimension).
+There's a yet to be deployed optimization that also deduplicates datasets that have exactly the same h3 tile coverage . There is _a lot_ of these in national datasets - duplicates on a country level (geography dimension) and even on yearly level (time dimension) which quickly add up to multiple gigabytes of storage.
 
 ## Querying
 
-##### For lower zoom levels (zoomed "out"), we aggregate dataset counts per lower resolution cells.
+#### For lower zoom levels (zoomed "out"), we aggregate dataset counts per lower resolution cells.
 
-And vice versa for higher zoom levels (zoomed "in") and higher resolution cells. The mapping between zoom levels and h3 resolutions can be found in [constants/h3.ts](worldex/blob/main/ui/src/constants/h3.ts). It is somewhat arbitrary, and was tuned during development based roughly on visuals and performance.
+And vice versa for higher zoom levels (zoomed "in") and higher resolution cells. The mapping between zoom levels and h3 resolutions can be found in [constants/h3.ts](worldex/blob/main/ui/src/constants/h3.ts). It is somewhat arbitrary, and was tuned during development based roughly on visual appearance and performance.
 
-##### We batch query dataset counts in tiles
+#### We batch query dataset counts in tiles
 
 One batch corresponds to an OSM/slippy map tile represented in a z/x/y notation. That said, we actually map h3 resolutions to aggregate on with an OSM z-index, and not the actual zoom level of the web map. It can be easy to confuse the two.
 
@@ -34,17 +34,15 @@ Another thing to note is that we map z-indices to h3 resolutions in a stepped ma
 
 https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Zoom_levels
 
-##### So what are the actual sql queries like?
+#### So what is the actual querying strategy?
 
-Our strategy is as follows:
+Per OSM tile, we use an h3 geospatial function to fill that rectangle with h3 indices of a given resolution. We refer to them as "fill" tiles from hereon.
 
-Per OSM tile, we use an h3 geospatial function to basically fill that rectangle with h3 indices of a given resolution. We refer to them as "fill" tiles from hereon.
-
-Per fill tile, we create an intermediate table (via cte) with another column being an array of all this tile's parents. We then join it with the datasets' h3 tiles if there's an equality between them and any of the tiles' parents or the tile itself.
+Per fill tile, we create an intermediate table (via cte) with all of its parent tiles (up to the lowest resolution). We then `JOIN` it with the datasets' h3 tiles if there's an equality between them and any of the fill tiles' parents or itself.
 
 This captures all dataset tiles that are of the same or lower resolutions of the fill tiles.
 
-**But what about tiles that are of higher resolutions?**
+##### But what about tiles that are of higher resolutions?
 
 We use a precomputed "lookup" table with "lookup" tiles telling us if a particular dataset has any compacted tile/s that is a child/ren of the lookup tile. Instead of doing expensive `WHERE EXISTS` queries, we can simply join the fill tiles with the lookup tiles to determine if the former contains any dataset tiles of higher resolution.
 

--- a/search.md
+++ b/search.md
@@ -1,0 +1,1 @@
+_Document the search heuristics here_


### PR DESCRIPTION
- Revise docs on how to provision local environments (and partly production builds on bare metal)
- Document strategy for storing and querying aggregated h3 datasets

## Next todos:
- Document search heuristics
- We currently publicly host a sql dump on https://storage.googleapis.com/worldex-dump/worldex.dump . Ideally we can decouple it from the google cloud storage bucket.
- Similarly, we have parquet files of pre-indexed datasets which are loaded into the db as an alternative way of populating the database. These parquet files are currently on a personal aws bucket, and should be publicly hosted elsewhere.