### PR TITLE
ui: Rebalance color binning after getting search results

### DIFF
--- a/ui/src/utils/splitIntoBins.ts
+++ b/ui/src/utils/splitIntoBins.ts
@@ -1,0 +1,17 @@
+export const splitIntoBins = (n: number, maxBins: number = 5): number[] => {
+  const baseSize = Math.floor(n / maxBins);
+  const binsWithExtra = n % maxBins;
+  const bins = Array(maxBins).fill(baseSize);
+  for (let i = 0; i < binsWithExtra; i++) {
+      bins[i] += 1;
+  }
+  return bins.filter((b: number) => b > 0);
+}
+
+export const splitIntoDomains = (n: number, maxBins: number = 5): number[] => (
+  splitIntoBins(n, maxBins).reduce((acc: number[], curr: number, idx: number) => (
+    idx === 0 ? [curr] : [...acc, curr + acc[idx - 1]]
+  ), [] as number[])
+);
+
+export default splitIntoDomains;

--- a/ui/src/utils/splitIntoBins.ts
+++ b/ui/src/utils/splitIntoBins.ts
@@ -2,11 +2,12 @@ export const splitIntoBins = (n: number, maxBins: number = 5): number[] => {
   const baseSize = Math.floor(n / maxBins);
   const binsWithExtra = n % maxBins;
   const bins = Array(maxBins).fill(baseSize);
+  // eslint-disable-next-line no-plusplus
   for (let i = 0; i < binsWithExtra; i++) {
-      bins[i] += 1;
+    bins[i] += 1;
   }
   return bins.filter((b: number) => b > 0);
-}
+};
 
 export const splitIntoDomains = (n: number, maxBins: number = 5): number[] => (
   splitIntoBins(n, maxBins).reduce((acc: number[], curr: number, idx: number) => (


### PR DESCRIPTION
Right now, we have fixed color bins for dataset counts per h3 tile. These do not rebalance after a user performs a search, which means a search with "few" results will mean most tiles will have a light color even if they have "plenty" datasets relative to the search results.

To illustrate below, notice how the hex tiles uses the lightest color reserved for the bin with the least count despite there being only a single search result. 

<img width="1307" alt="image" src="https://github.com/avsolatorio/worldex/assets/8906131/fec7c7fa-0c23-47c4-a6e2-5047a828f93e">

This PR rebalances the color bins (to roughly equal sizes/ranges for simplicity, e.g. 23 datasets will have result to bin domains of 5, 10, 15, 19, 23) with respect to the number of dataset search results. 

One gotcha is that rebalancing is done with respect to the total search result count, rather than the tile with the highest dataset count (that would involve low-level deck.gl code, which is more complex but should still be feasible)

# Screenshots
## Default (no search applied)
![image](https://github.com/avsolatorio/worldex/assets/8906131/b94fdd90-b902-4258-8515-57bcbca664ce)

## Rebalanced after search results
![image](https://github.com/avsolatorio/worldex/assets/8906131/495f7340-cce5-4c90-8ea3-247aafad2230)